### PR TITLE
Add additional exclusions for phpMyAdmin 5.1.3

### DIFF
--- a/plugins/phpmyadmin-rule-exclusions-before.conf
+++ b/plugins/phpmyadmin-rule-exclusions-before.conf
@@ -426,16 +426,3 @@ SecRule REQUEST_FILENAME "@endsWith /db_routines.php" \
     SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
         "t:none,\
         ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:item_definition"
-
-# Setup
-SecRule REQUEST_URI "@endsWith /index.php?route=/config/set" \
-    "id:9513340,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'phpmyadmin-rule-exclusions-plugin/1.0.1',\
-    chain"
-    SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
-        "t:none,\
-        ctl:ruleRemoveTargetById=942110;ARGS:value"

--- a/plugins/phpmyadmin-rule-exclusions-before.conf
+++ b/plugins/phpmyadmin-rule-exclusions-before.conf
@@ -315,10 +315,14 @@ SecAction \
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
     ctl:ruleRemoveTargetById=942100;REQUEST_COOKIES:auto_saved_sql,\
+    ctl:ruleRemoveTargetById=932200;REQUEST_COOKIES:pmaAuth-1,\
     ctl:ruleRemoveTargetById=942200;REQUEST_COOKIES:pmaAuth-1,\
     ctl:ruleRemoveTargetById=942340;REQUEST_COOKIES:pmaAuth-1,\
+    ctl:ruleRemoveTargetById=942370;REQUEST_COOKIES:pmaAuth-1,\
+    ctl:ruleRemoveTargetById=932200;REQUEST_COOKIES:pmaUser-1,\
     ctl:ruleRemoveTargetById=942200;REQUEST_COOKIES:pmaUser-1,\
     ctl:ruleRemoveTargetById=942340;REQUEST_COOKIES:pmaUser-1,\
+    ctl:ruleRemoveTargetById=942370;REQUEST_COOKIES:pmaUser-1,\
     ctl:ruleRemoveTargetById=942200;REQUEST_COOKIES:pma_console_config,\
     ctl:ruleRemoveTargetById=942260;REQUEST_COOKIES:pma_console_config"
 
@@ -422,3 +426,16 @@ SecRule REQUEST_FILENAME "@endsWith /db_routines.php" \
     SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
         "t:none,\
         ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:item_definition"
+
+# Setup
+SecRule REQUEST_URI "@endsWith /index.php?route=/config/set" \
+    "id:9513340,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'phpmyadmin-rule-exclusions-plugin/1.0.1',\
+    chain"
+    SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
+        "t:none,\
+        ctl:ruleRemoveTargetById=942110;ARGS:value"


### PR DESCRIPTION
I tested out the plugin on a phpMyAdmin 5.1.3 install.

I installed phpMyAdmin from source and had trouble running the [yarn command](https://docs.phpmyadmin.net/en/latest/setup.html#installing-from-git) so my phpMyAdmin looks ugly and unstyled, so I wasn't able to fully test the application.

In any case, the plugin runs and the exclusions are applied.

I already found a few false positives that prevented me from logging in, so I expanded the exclusions.

If somebody else has a well-running recent phpMyAdmin version, a bit of testing seems warranted. For time reasons, I can't really test further in the next days.