### PR TITLE
Adding support for PMA 5.1 and up

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,17 @@ For full and up to date instructions for the different available plugin
 installation methods, refer to [How to Install a Plugin](https://coreruleset.org/docs/concepts/plugins/#how-to-install-a-plugin)
 in the official CRS documentation.
 
+## Configuration
+
+All settings can be done in file `plugins/phpmyadmin-rule-exclusions-config.conf`.
+
+### tx.phpmyadmin-rule-exclusions-plugin_url_format
+
+phpMyAdmin completely changed URL structure from version 5.1.0 so, if you are
+running older version, set this setting to `old`. Otherwise, keep it to `v51`.
+
+Default value: v51
+
 ## Testing
 
 After the plugin is enabled, your phpMyAdmin instance should work without any

--- a/plugins/phpmyadmin-rule-exclusions-after.conf
+++ b/plugins/phpmyadmin-rule-exclusions-after.conf
@@ -13,6 +13,9 @@
 # Rule ID block base: 9,513,000 - 9,513,999
 # Plugin version: 1.0.0
 
+# Session cookies whitelist + persistent cookies
+# These cookies may persist beyond sessions and may block a user when trying
+# to access phpMyAdmin for a second time.
 SecRuleUpdateTargetById 942200 "!REQUEST_COOKIES:/^pmaAuth-[0-9]+$/"
 SecRuleUpdateTargetById 942200 "!REQUEST_COOKIES:/^pmaUser-[0-9]+$/"
 SecRuleUpdateTargetById 942340 "!REQUEST_COOKIES:/^pmaAuth-[0-9]+$/"

--- a/plugins/phpmyadmin-rule-exclusions-after.conf
+++ b/plugins/phpmyadmin-rule-exclusions-after.conf
@@ -21,6 +21,4 @@ SecRuleUpdateTargetById 942200 "!REQUEST_COOKIES:/^pmaUser-[0-9]+$/"
 SecRuleUpdateTargetById 942340 "!REQUEST_COOKIES:/^pmaAuth-[0-9]+$/"
 SecRuleUpdateTargetById 942340 "!REQUEST_COOKIES:/^pmaUser-[0-9]+$/"
 
-SecRuleUpdateTargetById 942100 "!ARGS:/^rows_to_delete\[[0-9]+\]$"
-
-SecRule ARGS:route "@rx ^/table/export(?:/rows)?$" \
+SecRuleUpdateTargetById 942100 "!ARGS:/^rows_to_delete\[[0-9]+\]$/"

--- a/plugins/phpmyadmin-rule-exclusions-after.conf
+++ b/plugins/phpmyadmin-rule-exclusions-after.conf
@@ -1,6 +1,6 @@
 # ------------------------------------------------------------------------
 # OWASP ModSecurity Core Rule Set Plugin
-# Copyright (c) 2021-2022 Core Rule Set project. All rights reserved.
+# Copyright (c) 2021-2023 Core Rule Set project. All rights reserved.
 #
 # The OWASP ModSecurity Core Rule Set plugins are distributed under
 # Apache Software License (ASL) version 2
@@ -20,3 +20,7 @@ SecRuleUpdateTargetById 942200 "!REQUEST_COOKIES:/^pmaAuth-[0-9]+$/"
 SecRuleUpdateTargetById 942200 "!REQUEST_COOKIES:/^pmaUser-[0-9]+$/"
 SecRuleUpdateTargetById 942340 "!REQUEST_COOKIES:/^pmaAuth-[0-9]+$/"
 SecRuleUpdateTargetById 942340 "!REQUEST_COOKIES:/^pmaUser-[0-9]+$/"
+
+SecRuleUpdateTargetById 942100 "!ARGS:/^rows_to_delete\[[0-9]+\]$"
+
+SecRule ARGS:route "@rx ^/table/export(?:/rows)?$" \

--- a/plugins/phpmyadmin-rule-exclusions-after.conf
+++ b/plugins/phpmyadmin-rule-exclusions-after.conf
@@ -1,0 +1,19 @@
+# ------------------------------------------------------------------------
+# OWASP ModSecurity Core Rule Set Plugin
+# Copyright (c) 2021-2022 Core Rule Set project. All rights reserved.
+#
+# The OWASP ModSecurity Core Rule Set plugins are distributed under
+# Apache Software License (ASL) version 2
+# Please see the enclosed LICENSE file for full details.
+# ------------------------------------------------------------------------
+
+# OWASP CRS Plugin
+# Plugin name: phpmyadmin-rule-exclusions
+# Plugin description: 
+# Rule ID block base: 9,513,000 - 9,513,999
+# Plugin version: 1.0.0
+
+SecRuleUpdateTargetById 942200 "!REQUEST_COOKIES:/^pmaAuth-[0-9]+$/"
+SecRuleUpdateTargetById 942200 "!REQUEST_COOKIES:/^pmaUser-[0-9]+$/"
+SecRuleUpdateTargetById 942340 "!REQUEST_COOKIES:/^pmaAuth-[0-9]+$/"
+SecRuleUpdateTargetById 942340 "!REQUEST_COOKIES:/^pmaUser-[0-9]+$/"

--- a/plugins/phpmyadmin-rule-exclusions-before.conf
+++ b/plugins/phpmyadmin-rule-exclusions-before.conf
@@ -1,6 +1,6 @@
 # ------------------------------------------------------------------------
 # OWASP ModSecurity Core Rule Set Plugin
-# Copyright (c) 2021-2022 Core Rule Set project. All rights reserved.
+# Copyright (c) 2021-2023 Core Rule Set project. All rights reserved.
 #
 # The OWASP ModSecurity Core Rule Set plugins are distributed under
 # Apache Software License (ASL) version 2

--- a/plugins/phpmyadmin-rule-exclusions-before.conf
+++ b/plugins/phpmyadmin-rule-exclusions-before.conf
@@ -336,7 +336,8 @@ SecRule REQUEST_FILENAME "@endsWith /export.php" \
     ctl:ruleRemoveTargetById=942110;ARGS:csv_escaped,\
     ctl:ruleRemoveTargetById=942330;ARGS:csv_escaped,\
     ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
-    ctl:ruleRemoveTargetById=932100;ARGS:sql_query"
+    ctl:ruleRemoveTargetById=932100;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932115;ARGS:sql_query"
 
 # Table export
 SecRule REQUEST_FILENAME "@endsWith /tbl_export.php" \
@@ -346,7 +347,9 @@ SecRule REQUEST_FILENAME "@endsWith /tbl_export.php" \
     t:none,\
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
-    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query"
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932100;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932115;ARGS:sql_query"
 
 # Sending error report
 SecRule REQUEST_FILENAME "@endsWith /error_report.php" \
@@ -747,7 +750,8 @@ SecRule ARGS:route "@rx ^/table/export(?:/rows)?$" \
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
     ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
-    ctl:ruleRemoveTargetById=932100;ARGS:sql_query"
+    ctl:ruleRemoveTargetById=932100;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932115;ARGS:sql_query"
 
 # Export
 SecRule ARGS:route "@rx ^/export(?:/tables)?$" \
@@ -758,7 +762,8 @@ SecRule ARGS:route "@rx ^/export(?:/tables)?$" \
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
     ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
-    ctl:ruleRemoveTargetById=932100;ARGS:sql_query"
+    ctl:ruleRemoveTargetById=932100;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932115;ARGS:sql_query"
 
 # Sending error report
 SecRule ARGS:route "@streq /error-report" \

--- a/plugins/phpmyadmin-rule-exclusions-before.conf
+++ b/plugins/phpmyadmin-rule-exclusions-before.conf
@@ -36,18 +36,13 @@ SecAction \
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
     ctl:ruleRemoveTargetById=942140;ARGS:db,\
+    ctl:ruleRemoveTargetById=932200;REQUEST_COOKIES,\
     ctl:ruleRemoveTargetById=941100;REQUEST_COOKIES,\
     ctl:ruleRemoveTargetById=941120;REQUEST_COOKIES,\
+    ctl:ruleRemoveTargetById=942200;REQUEST_COOKIES,\
+    ctl:ruleRemoveTargetById=942340;REQUEST_COOKIES,\
+    ctl:ruleRemoveTargetById=942370;REQUEST_COOKIES,\
     ctl:ruleRemoveTargetById=942100;REQUEST_COOKIES:auto_saved_sql,\
-    ctl:ruleRemoveTargetById=932200;REQUEST_COOKIES:pmaAuth-1,\
-    ctl:ruleRemoveTargetById=942200;REQUEST_COOKIES:pmaAuth-1,\
-    ctl:ruleRemoveTargetById=942340;REQUEST_COOKIES:pmaAuth-1,\
-    ctl:ruleRemoveTargetById=942370;REQUEST_COOKIES:pmaAuth-1,\
-    ctl:ruleRemoveTargetById=932200;REQUEST_COOKIES:pmaUser-1,\
-    ctl:ruleRemoveTargetById=942200;REQUEST_COOKIES:pmaUser-1,\
-    ctl:ruleRemoveTargetById=942340;REQUEST_COOKIES:pmaUser-1,\
-    ctl:ruleRemoveTargetById=942370;REQUEST_COOKIES:pmaUser-1,\
-    ctl:ruleRemoveTargetById=942200;REQUEST_COOKIES:pma_console_config,\
     ctl:ruleRemoveTargetById=942260;REQUEST_COOKIES:pma_console_config"
 
 # Setup - Overview

--- a/plugins/phpmyadmin-rule-exclusions-before.conf
+++ b/plugins/phpmyadmin-rule-exclusions-before.conf
@@ -298,7 +298,8 @@ SecRule REQUEST_FILENAME "@endsWith /export.php" \
     ctl:ruleRemoveTargetById=942330;ARGS:csv_enclosed,\
     ctl:ruleRemoveTargetById=942110;ARGS:csv_escaped,\
     ctl:ruleRemoveTargetById=942330;ARGS:csv_escaped,\
-    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query"
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=942140;ARGS:db"
 
 # Table export
 SecRule REQUEST_FILENAME "@endsWith /tbl_export.php" \
@@ -395,7 +396,8 @@ SecRule REQUEST_FILENAME "@endsWith /tbl_structure.php" \
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
     ctl:ruleRemoveTargetById=942190;ARGS,\
     ctl:ruleRemoveTargetById=942470;ARGS,\
-    ctl:ruleRemoveTargetById=942140;ARGS:db"
+    ctl:ruleRemoveTargetById=942140;ARGS:db,\
+    ctl:ruleRemoveTargetById=942100;ARGS:field_extra_orig[1]"
 
 # Query -> Multi-table query
 SecRule REQUEST_FILENAME "@endsWith /db_multi_table_query.php" \
@@ -736,7 +738,8 @@ SecRule ARGS:route "@streq /database/export" \
     ctl:ruleRemoveTargetById=942330;ARGS:csv_enclosed,\
     ctl:ruleRemoveTargetById=942110;ARGS:csv_escaped,\
     ctl:ruleRemoveTargetById=942330;ARGS:csv_escaped,\
-    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query"
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=942140;ARGS:db"
 
 # Table export
 SecRule ARGS:route "@streq /table/export" \
@@ -812,7 +815,8 @@ SecRule ARGS:route "@streq /table/structure/change" \
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
     ctl:ruleRemoveTargetById=942190;ARGS,\
     ctl:ruleRemoveTargetById=942470;ARGS,\
-    ctl:ruleRemoveTargetById=942140;ARGS:db"
+    ctl:ruleRemoveTargetById=942140;ARGS:db,\
+    ctl:ruleRemoveTargetById=942100;ARGS:field_extra_orig[1]"
 
 # Query -> Multi-table query
 SecRule ARGS:route "@streq /database/multi-table-query" \

--- a/plugins/phpmyadmin-rule-exclusions-before.conf
+++ b/plugins/phpmyadmin-rule-exclusions-before.conf
@@ -284,7 +284,8 @@ SecRule REQUEST_FILENAME "@endsWith /db_events.php" \
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
     ctl:ruleRemoveTargetById=932115;ARGS:item_definition,\
-    ctl:ruleRemoveTargetById=942350;ARGS:item_definition"
+    ctl:ruleRemoveTargetById=942350;ARGS:item_definition,\
+    ctl:ruleRemoveTargetById=942360;ARGS:item_definition"
 
 # Database export
 SecRule REQUEST_FILENAME "@endsWith /export.php" \
@@ -724,7 +725,8 @@ SecRule ARGS:route "@streq /database/events" \
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
     ctl:ruleRemoveTargetById=932115;ARGS:item_definition,\
-    ctl:ruleRemoveTargetById=942350;ARGS:item_definition"
+    ctl:ruleRemoveTargetById=942350;ARGS:item_definition,\
+    ctl:ruleRemoveTargetById=942360;ARGS:item_definition"
 
 # Database export
 SecRule ARGS:route "@streq /database/export" \

--- a/plugins/phpmyadmin-rule-exclusions-before.conf
+++ b/plugins/phpmyadmin-rule-exclusions-before.conf
@@ -179,6 +179,7 @@ SecRule REQUEST_FILENAME "@endsWith /sql.php" \
     t:none,\
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetById=953100;RESPONSE_BODY,\
     ctl:ruleRemoveTargetById=920230;ARGS:goto,\
     ctl:ruleRemoveTargetById=942100;ARGS:goto,\
     ctl:ruleRemoveTargetById=942200;ARGS:goto,\
@@ -575,6 +576,7 @@ SecRule ARGS:route "@streq /sql" \
     t:none,\
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetById=953100;RESPONSE_BODY,\
     ctl:ruleRemoveTargetById=920230;ARGS:goto,\
     ctl:ruleRemoveTargetById=942100;ARGS:goto,\
     ctl:ruleRemoveTargetById=942200;ARGS:goto,\

--- a/plugins/phpmyadmin-rule-exclusions-before.conf
+++ b/plugins/phpmyadmin-rule-exclusions-before.conf
@@ -846,7 +846,7 @@ SecRule ARGS:route "@streq /table/structure/change" \
     ctl:ruleRemoveTargetById=942100;ARGS:field_extra_orig[1]"
 
 # Query -> Multi-table query
-SecRule ARGS:route "@streq /database/multi-table-query" \
+SecRule ARGS:route "@rx /database/multi-table-query(?:/query)?$" \
     "id:9513810,\
     phase:1,\
     pass,\

--- a/plugins/phpmyadmin-rule-exclusions-before.conf
+++ b/plugins/phpmyadmin-rule-exclusions-before.conf
@@ -244,6 +244,7 @@ SecRule REQUEST_FILENAME "@endsWith /import.php" \
     ctl:ruleRemoveTargetById=942110;ARGS:ldi_terminated,\
     ctl:ruleRemoveTargetById=942140;ARGS:db,\
     ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:prev_sql_query,\
+    ctl:ruleRemoveTargetById=932100;ARGS:prev_sql_query,\
     ctl:ruleRemoveTargetById=932130;ARGS:prev_sql_query,\
     ctl:ruleRemoveTargetById=933210;ARGS:prev_sql_query,\
     ctl:ruleRemoveTargetById=942110;ARGS:sql_delimiter,\
@@ -685,6 +686,7 @@ SecRule ARGS:route "@streq /import" \
     ctl:ruleRemoveTargetById=942110;ARGS:ldi_terminated,\
     ctl:ruleRemoveTargetById=942140;ARGS:db,\
     ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:prev_sql_query,\
+    ctl:ruleRemoveTargetById=932100;ARGS:prev_sql_query,\
     ctl:ruleRemoveTargetById=932130;ARGS:prev_sql_query,\
     ctl:ruleRemoveTargetById=933210;ARGS:prev_sql_query,\
     ctl:ruleRemoveTargetById=942110;ARGS:sql_delimiter,\

--- a/plugins/phpmyadmin-rule-exclusions-before.conf
+++ b/plugins/phpmyadmin-rule-exclusions-before.conf
@@ -30,7 +30,19 @@ SecRule REQUEST_FILENAME "@rx /setup/(?:index\.php)?$" \
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
     ctl:ruleRemoveTargetById=953110;RESPONSE_BODY,\
-    ctl:ruleRemoveTargetById=953110;TX:response_body_decompressed"
+    ctl:ruleRemoveTargetById=953110;TX:response_body_decompressed,\
+    ctl:ruleRemoveTargetById=932120;ARGS_NAMES:Export-csv_separator,\
+    ctl:ruleRemoveTargetById=932120;ARGS_NAMES:Export-csv_separator-userprefs-allow,\
+    ctl:ruleRemoveTargetById=932120;ARGS_NAMES:Export-csv_enclosed,\
+    ctl:ruleRemoveTargetById=932120;ARGS_NAMES:Export-csv_enclosed-userprefs-allow,\
+    ctl:ruleRemoveTargetById=932120;ARGS_NAMES:Export-csv_escaped,\
+    ctl:ruleRemoveTargetById=932120;ARGS_NAMES:Export-csv_escaped-userprefs-allow,\
+    ctl:ruleRemoveTargetById=932120;ARGS_NAMES:Export-csv_terminated,\
+    ctl:ruleRemoveTargetById=932120;ARGS_NAMES:Export-csv_terminated-userprefs-allow,\
+    ctl:ruleRemoveTargetById=932120;ARGS_NAMES:Export-csv_null,\
+    ctl:ruleRemoveTargetById=932120;ARGS_NAMES:Export-csv_null-userprefs-allow,\
+    ctl:ruleRemoveTargetById=932120;ARGS_NAMES:Export-csv_removeCRLF-userprefs-allow,\
+    ctl:ruleRemoveTargetById=932120;ARGS_NAMES:Export-csv_columns-userprefs-allow"
 
 # Setup - Export
 SecRule REQUEST_FILENAME "@endsWith /setup/config.php" \

--- a/plugins/phpmyadmin-rule-exclusions-before.conf
+++ b/plugins/phpmyadmin-rule-exclusions-before.conf
@@ -222,6 +222,7 @@ SecRule REQUEST_FILENAME "@endsWith /lint.php" \
     ctl:ruleRemoveTargetById=932110;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932115;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932130;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932140;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932150;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932160;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=933100;ARGS:sql_query,\
@@ -617,6 +618,7 @@ SecRule ARGS:route "@streq /lint" \
     ctl:ruleRemoveTargetById=932110;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932115;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932130;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932140;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932150;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932160;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=933100;ARGS:sql_query,\

--- a/plugins/phpmyadmin-rule-exclusions-before.conf
+++ b/plugins/phpmyadmin-rule-exclusions-before.conf
@@ -479,7 +479,7 @@ SecRule REQUEST_FILENAME "@endsWith /db_sql_autocomplete.php" \
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
     ctl:ruleRemoveTargetById=942140;ARGS:db"
 
-# Search - Find and replace
+# Search - Find and replace (table)
 SecRule REQUEST_FILENAME "@endsWith /tbl_find_replace.php" \
     "id:9513450,\
     phase:1,\
@@ -489,7 +489,7 @@ SecRule REQUEST_FILENAME "@endsWith /tbl_find_replace.php" \
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
     ctl:ruleRemoveTargetById=942140;ARGS:db"
 
-# Search - Zoom search
+# Search - Zoom search (table)
 SecRule REQUEST_FILENAME "@endsWith /tbl_zoom_select.php" \
     "id:9513460,\
     phase:1,\
@@ -918,9 +918,29 @@ SecRule ARGS:route "@streq /database/sql/autocomplete" \
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
     ctl:ruleRemoveTargetById=942140;ARGS:db"
 
+# Search - Find and replace (table)
+SecRule ARGS:route "@streq /table/find-replace" \
+    "id:9513860,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetById=942140;ARGS:db"
+
+# Search - Zoom search (table)
+SecRule ARGS:route "@streq /table/zoom-search" \
+    "id:9513870,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetById=942140;ARGS:db"
+
 # Setup
 SecRule ARGS:route "@streq /config/set" \
-    "id:9513860,\
+    "id:9513880,\
     phase:1,\
     pass,\
     t:none,\
@@ -930,7 +950,7 @@ SecRule ARGS:route "@streq /config/set" \
 
 # Databases, sorting
 SecRule ARGS:route "@streq /server/databases" \
-    "id:9513870,\
+    "id:9513890,\
     phase:1,\
     pass,\
     t:none,\

--- a/plugins/phpmyadmin-rule-exclusions-before.conf
+++ b/plugins/phpmyadmin-rule-exclusions-before.conf
@@ -790,7 +790,7 @@ SecRule ARGS:route "@streq /database/export" \
     ctl:ruleRemoveTargetById=932100;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932115;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=951210;TX:sql_error_match,\
-    ctl:ruleRemoveTargetById=951210;RESPONSE_BODY,\
+    ctl:ruleRemoveTargetById=951210;RESPONSE_BODY"
 
 # Table export - page renderer
 SecRule ARGS:route "@rx ^/table/export(?:/rows)?$" \

--- a/plugins/phpmyadmin-rule-exclusions-before.conf
+++ b/plugins/phpmyadmin-rule-exclusions-before.conf
@@ -36,10 +36,6 @@ SecAction \
     ctl:ruleRemoveTargetById=941100;REQUEST_COOKIES,\
     ctl:ruleRemoveTargetById=941120;REQUEST_COOKIES,\
     ctl:ruleRemoveTargetById=942100;REQUEST_COOKIES:auto_saved_sql,\
-    ctl:ruleRemoveTargetById=942200;REQUEST_COOKIES:pmaAuth-1,\
-    ctl:ruleRemoveTargetById=942340;REQUEST_COOKIES:pmaAuth-1,\
-    ctl:ruleRemoveTargetById=942200;REQUEST_COOKIES:pmaUser-1,\
-    ctl:ruleRemoveTargetById=942340;REQUEST_COOKIES:pmaUser-1,\
     ctl:ruleRemoveTargetById=942200;REQUEST_COOKIES:pma_console_config,\
     ctl:ruleRemoveTargetById=942260;REQUEST_COOKIES:pma_console_config"
 

--- a/plugins/phpmyadmin-rule-exclusions-before.conf
+++ b/plugins/phpmyadmin-rule-exclusions-before.conf
@@ -156,8 +156,10 @@ SecRule REQUEST_FILENAME "@endsWith /tbl_replace.php" \
     ctl:ruleRemoveTargetById=942170;ARGS,\
     ctl:ruleRemoveTargetById=942190;ARGS,\
     ctl:ruleRemoveTargetById=942230;ARGS,\
+    ctl:ruleRemoveTargetById=920270;ARGS:fields[multi_edit][0][],\
     ctl:ruleRemoveTargetById=930100;ARGS:fields[multi_edit][0][],\
     ctl:ruleRemoveTargetById=930110;ARGS:fields[multi_edit][0][],\
+    ctl:ruleRemoveTargetById=933170;ARGS:fields[multi_edit][0][],\
     ctl:ruleRemoveTargetById=933210;ARGS:fields[multi_edit][0][]"
 
 # Downloading row data
@@ -378,7 +380,8 @@ SecRule REQUEST_FILENAME "@endsWith /view_create.php" \
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
     ctl:ruleRemoveTargetById=941100;ARGS:view[as],\
     ctl:ruleRemoveTargetById=942100;ARGS:view[as],\
-    ctl:ruleRemoveTargetById=942360;ARGS:view[as]"
+    ctl:ruleRemoveTargetById=942360;ARGS:view[as],\
+    ctl:ruleRemoveTargetById=942100;ARGS:sql_query"
 
 # Search rows in a table
 # MySQL chars such as '%' trigger rules on ARGS:criteriaColumnTypes[n]
@@ -561,8 +564,10 @@ SecRule ARGS:route "@streq /table/replace" \
     ctl:ruleRemoveTargetById=942170;ARGS,\
     ctl:ruleRemoveTargetById=942190;ARGS,\
     ctl:ruleRemoveTargetById=942230;ARGS,\
+    ctl:ruleRemoveTargetById=920270;ARGS:fields[multi_edit][0][],\
     ctl:ruleRemoveTargetById=930100;ARGS:fields[multi_edit][0][],\
     ctl:ruleRemoveTargetById=930110;ARGS:fields[multi_edit][0][],\
+    ctl:ruleRemoveTargetById=933170;ARGS:fields[multi_edit][0][],\
     ctl:ruleRemoveTargetById=933210;ARGS:fields[multi_edit][0][]"
 
 # Downloading row data
@@ -796,7 +801,8 @@ SecRule ARGS:route "@streq /view/create" \
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
     ctl:ruleRemoveTargetById=941100;ARGS:view[as],\
     ctl:ruleRemoveTargetById=942100;ARGS:view[as],\
-    ctl:ruleRemoveTargetById=942360;ARGS:view[as]"
+    ctl:ruleRemoveTargetById=942360;ARGS:view[as],\
+    ctl:ruleRemoveTargetById=942100;ARGS:sql_query"
 
 # Search rows in a table
 # MySQL chars such as '%' trigger rules on ARGS:criteriaColumnTypes[n]

--- a/plugins/phpmyadmin-rule-exclusions-before.conf
+++ b/plugins/phpmyadmin-rule-exclusions-before.conf
@@ -219,6 +219,7 @@ SecRule REQUEST_FILENAME "@endsWith /lint.php" \
     ctl:ruleRemoveTargetById=921110;REQUEST_BODY,\
     ctl:ruleRemoveTargetById=921110;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=921130;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=930120;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932100;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932105;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932110;ARGS:sql_query,\
@@ -287,6 +288,7 @@ SecRule REQUEST_FILENAME "@endsWith /import.php" \
     ctl:ruleRemoveTargetByTag=attack-xss;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=921110;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=921130;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=930120;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932100;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932105;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932110;ARGS:sql_query,\
@@ -622,6 +624,7 @@ SecRule ARGS:route "@streq /lint" \
     ctl:ruleRemoveTargetById=921110;REQUEST_BODY,\
     ctl:ruleRemoveTargetById=921110;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=921130;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=930120;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932100;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932105;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932110;ARGS:sql_query,\
@@ -693,6 +696,7 @@ SecRule ARGS:route "@streq /import" \
     ctl:ruleRemoveTargetByTag=attack-xss;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=921110;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=921130;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=930120;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932100;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932105;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932110;ARGS:sql_query,\

--- a/plugins/phpmyadmin-rule-exclusions-before.conf
+++ b/plugins/phpmyadmin-rule-exclusions-before.conf
@@ -26,6 +26,8 @@ SecRule TX:phpmyadmin-rule-exclusions-plugin_enabled "@eq 0" "id:9513099,phase:1
 # Session cookies whitelist + persistent cookies
 # These cookies may persist beyond sessions and may block a user when trying
 # to access phpMyAdmin for a second time.
+# Rule 942140 is disabled for "db" argument because of the "information_schema"
+# keyword.
 SecAction \
     "id:9513100,\
     phase:1,\
@@ -33,6 +35,7 @@ SecAction \
     t:none,\
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetById=942140;ARGS:db,\
     ctl:ruleRemoveTargetById=941100;REQUEST_COOKIES,\
     ctl:ruleRemoveTargetById=941120;REQUEST_COOKIES,\
     ctl:ruleRemoveTargetById=942100;REQUEST_COOKIES:auto_saved_sql,\
@@ -176,7 +179,6 @@ SecRule REQUEST_FILENAME "@endsWith /sql.php" \
     t:none,\
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
-    ctl:ruleRemoveTargetById=942140;ARGS:db,\
     ctl:ruleRemoveTargetById=920230;ARGS:goto,\
     ctl:ruleRemoveTargetById=942100;ARGS:goto,\
     ctl:ruleRemoveTargetById=942200;ARGS:goto,\
@@ -244,8 +246,7 @@ SecRule REQUEST_FILENAME "@endsWith /tbl_sql.php" \
     ctl:ruleRemoveTargetById=932100;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=933210;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=941100;ARGS:sql_query,\
-    ctl:ruleRemoveTargetById=941160;ARGS:sql_query,\
-    ctl:ruleRemoveTargetById=942140;ARGS:db"
+    ctl:ruleRemoveTargetById=941160;ARGS:sql_query"
 
 # Opening custom SQL editor (databases)
 SecRule REQUEST_FILENAME "@endsWith /db_sql.php" \
@@ -255,8 +256,7 @@ SecRule REQUEST_FILENAME "@endsWith /db_sql.php" \
     t:none,\
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
-    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
-    ctl:ruleRemoveTargetById=942140;ARGS:db"
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query"
 
 # Importing data and executing of custom SQL
 SecRule REQUEST_FILENAME "@endsWith /import.php" \
@@ -275,7 +275,6 @@ SecRule REQUEST_FILENAME "@endsWith /import.php" \
     ctl:ruleRemoveTargetById=942110;ARGS:ldi_enclosed,\
     ctl:ruleRemoveTargetById=942330;ARGS:ldi_enclosed,\
     ctl:ruleRemoveTargetById=942110;ARGS:ldi_terminated,\
-    ctl:ruleRemoveTargetById=942140;ARGS:db,\
     ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:prev_sql_query,\
     ctl:ruleRemoveTargetById=932100;ARGS:prev_sql_query,\
     ctl:ruleRemoveTargetById=932130;ARGS:prev_sql_query,\
@@ -334,8 +333,7 @@ SecRule REQUEST_FILENAME "@endsWith /export.php" \
     ctl:ruleRemoveTargetById=942330;ARGS:csv_enclosed,\
     ctl:ruleRemoveTargetById=942110;ARGS:csv_escaped,\
     ctl:ruleRemoveTargetById=942330;ARGS:csv_escaped,\
-    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
-    ctl:ruleRemoveTargetById=942140;ARGS:db"
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query"
 
 # Table export
 SecRule REQUEST_FILENAME "@endsWith /tbl_export.php" \
@@ -345,8 +343,7 @@ SecRule REQUEST_FILENAME "@endsWith /tbl_export.php" \
     t:none,\
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
-    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
-    ctl:ruleRemoveTargetById=942140;ARGS:db"
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query"
 
 # Sending error report
 SecRule REQUEST_FILENAME "@endsWith /error_report.php" \
@@ -384,8 +381,7 @@ SecRule REQUEST_FILENAME "@endsWith /tbl_select.php" \
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
     ctl:ruleRemoveTargetById=942440;ARGS:orderByColumn,\
     ctl:ruleRemoveTargetById=942470;ARGS,\
-    ctl:ruleRemoveTargetById=942300;ARGS,\
-    ctl:ruleRemoveTargetById=942140;ARGS:db"
+    ctl:ruleRemoveTargetById=942300;ARGS"
 
 # Structure -> Add columns
 # Column types contain SQL keyword. One commonly adds multiple columns.
@@ -412,7 +408,6 @@ SecRule REQUEST_FILENAME "@endsWith /tbl_structure.php" \
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
     ctl:ruleRemoveTargetById=942190;ARGS,\
     ctl:ruleRemoveTargetById=942470;ARGS,\
-    ctl:ruleRemoveTargetById=942140;ARGS:db,\
     ctl:ruleRemoveTargetById=942100;ARGS:field_extra_orig[1]"
 
 # Query -> Multi-table query
@@ -445,7 +440,6 @@ SecRule REQUEST_FILENAME "@endsWith /server_privileges.php" \
     t:none,\
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
-    ctl:ruleRemoveTargetById=942140;ARGS:db,\
     ctl:ruleRemoveTargetById=942140;ARGS:checkprivsdb"
 
 # Routines -> Add routine
@@ -458,49 +452,9 @@ SecRule REQUEST_FILENAME "@endsWith /db_routines.php" \
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
     ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:item_definition"
 
-# Structure
-SecRule REQUEST_FILENAME "@endsWith /db_structure.php" \
-    "id:9513430,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
-    ctl:ruleRemoveTargetById=942140;ARGS:db"
-
-# SQL (autocomplete in editor)
-SecRule REQUEST_FILENAME "@endsWith /db_sql_autocomplete.php" \
-    "id:9513440,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
-    ctl:ruleRemoveTargetById=942140;ARGS:db"
-
-# Search - Find and replace (table)
-SecRule REQUEST_FILENAME "@endsWith /tbl_find_replace.php" \
-    "id:9513450,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
-    ctl:ruleRemoveTargetById=942140;ARGS:db"
-
-# Search - Zoom search (table)
-SecRule REQUEST_FILENAME "@endsWith /tbl_zoom_select.php" \
-    "id:9513460,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
-    ctl:ruleRemoveTargetById=942140;ARGS:db"
-
 # Databases, sorting
 SecRule REQUEST_FILENAME "@endsWith /server_databases.php" \
-    "id:9513470,\
+    "id:9513430,\
     phase:1,\
     pass,\
     t:none,\
@@ -620,7 +574,6 @@ SecRule ARGS:route "@streq /sql" \
     t:none,\
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
-    ctl:ruleRemoveTargetById=942140;ARGS:db,\
     ctl:ruleRemoveTargetById=920230;ARGS:goto,\
     ctl:ruleRemoveTargetById=942100;ARGS:goto,\
     ctl:ruleRemoveTargetById=942200;ARGS:goto,\
@@ -689,8 +642,7 @@ SecRule ARGS:route "@streq /table/sql" \
     ctl:ruleRemoveTargetById=932115;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=933210;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=941100;ARGS:sql_query,\
-    ctl:ruleRemoveTargetById=941160;ARGS:sql_query,\
-    ctl:ruleRemoveTargetById=942140;ARGS:db"
+    ctl:ruleRemoveTargetById=941160;ARGS:sql_query"
 
 # Opening custom SQL editor (databases)
 SecRule ARGS:route "@streq /database/sql" \
@@ -700,8 +652,7 @@ SecRule ARGS:route "@streq /database/sql" \
     t:none,\
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
-    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
-    ctl:ruleRemoveTargetById=942140;ARGS:db"
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query"
 
 # Importing data and executing of custom SQL
 SecRule ARGS:route "@streq /import" \
@@ -721,7 +672,6 @@ SecRule ARGS:route "@streq /import" \
     ctl:ruleRemoveTargetById=942110;ARGS:ldi_enclosed,\
     ctl:ruleRemoveTargetById=942330;ARGS:ldi_enclosed,\
     ctl:ruleRemoveTargetById=942110;ARGS:ldi_terminated,\
-    ctl:ruleRemoveTargetById=942140;ARGS:db,\
     ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:prev_sql_query,\
     ctl:ruleRemoveTargetById=932100;ARGS:prev_sql_query,\
     ctl:ruleRemoveTargetById=932115;ARGS:prev_sql_query,\
@@ -781,8 +731,7 @@ SecRule ARGS:route "@streq /database/export" \
     ctl:ruleRemoveTargetById=942330;ARGS:csv_enclosed,\
     ctl:ruleRemoveTargetById=942110;ARGS:csv_escaped,\
     ctl:ruleRemoveTargetById=942330;ARGS:csv_escaped,\
-    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
-    ctl:ruleRemoveTargetById=942140;ARGS:db"
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query"
 
 # Table export - page renderer
 SecRule ARGS:route "@rx ^/table/export(?:/rows)?$" \
@@ -802,7 +751,6 @@ SecRule ARGS:route "@rx ^/export(?:/tables)?$" \
     t:none,\
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
-    ctl:ruleRemoveTargetById=942140;ARGS:db,\
     ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query"
 
 # Sending error report
@@ -869,7 +817,6 @@ SecRule ARGS:route "@streq /table/structure/change" \
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
     ctl:ruleRemoveTargetById=942190;ARGS,\
     ctl:ruleRemoveTargetById=942470;ARGS,\
-    ctl:ruleRemoveTargetById=942140;ARGS:db,\
     ctl:ruleRemoveTargetById=942100;ARGS:field_extra_orig[1]"
 
 # Query -> Multi-table query
@@ -902,7 +849,6 @@ SecRule ARGS:route "@streq /server/privileges" \
     t:none,\
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
-    ctl:ruleRemoveTargetById=942140;ARGS:db,\
     ctl:ruleRemoveTargetById=942140;ARGS:checkprivsdb"
 
 # Routines -> Add routine
@@ -915,49 +861,9 @@ SecRule ARGS:route "@streq /database/routines" \
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
     ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:item_definition"
 
-# Structure
-SecRule ARGS:route "@streq /database/structure" \
-    "id:9513850,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
-    ctl:ruleRemoveTargetById=942140;ARGS:db"
-
-# SQL (autocomplete in editor)
-SecRule ARGS:route "@streq /database/sql/autocomplete" \
-    "id:9513860,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
-    ctl:ruleRemoveTargetById=942140;ARGS:db"
-
-# Search - Find and replace (table)
-SecRule ARGS:route "@streq /table/find-replace" \
-    "id:9513870,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
-    ctl:ruleRemoveTargetById=942140;ARGS:db"
-
-# Search - Zoom search (table)
-SecRule ARGS:route "@streq /table/zoom-search" \
-    "id:9513880,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
-    ctl:ruleRemoveTargetById=942140;ARGS:db"
-
 # Setup
 SecRule ARGS:route "@streq /config/set" \
-    "id:9513890,\
+    "id:9513850,\
     phase:1,\
     pass,\
     t:none,\
@@ -975,18 +881,8 @@ SecRule ARGS:route "@streq /server/databases" \
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
     ctl:ruleRemoveTargetById=942140;ARGS:sort_by"
 
-# Ping?
-SecRule ARGS:route "@streq /" \
-    "id:9513910,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
-    ctl:ruleRemoveTargetById=942140;ARGS:db"
-
 SecRule ARGS:route "@streq /import/simulate-dml" \
-    "id:9513920,\
+    "id:9513910,\
     phase:1,\
     pass,\
     t:none,\

--- a/plugins/phpmyadmin-rule-exclusions-before.conf
+++ b/plugins/phpmyadmin-rule-exclusions-before.conf
@@ -941,4 +941,15 @@ SecRule ARGS:route "@streq /database/structure/empty-table" \
     ctl:ruleRemoveTargetById=951230;TX:sql_error_match,\
     ctl:ruleRemoveTargetById=951230;RESPONSE_BODY"
 
+SecRule ARGS:route "@streq /database/sql/format" \
+    "id:9513900,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetById=942100;ARGS:sql,\
+    ctl:ruleRemoveTargetById=942190;ARGS:sql,\
+    ctl:ruleRemoveTargetById=942360;ARGS:sql"
+
 SecMarker "END-PHPMYADMIN-RULE-EXCLUSIONS-PLUGIN-V51-URL-FORMAT"

--- a/plugins/phpmyadmin-rule-exclusions-before.conf
+++ b/plugins/phpmyadmin-rule-exclusions-before.conf
@@ -612,7 +612,7 @@ SecRule ARGS:route "@streq /table/get-field" \
 # Deleting a row
 SecRule ARGS:route "@streq /sql" \
     "id:9513650,\
-    phase:1,\
+    phase:2,\
     pass,\
     t:none,\
     nolog,\

--- a/plugins/phpmyadmin-rule-exclusions-before.conf
+++ b/plugins/phpmyadmin-rule-exclusions-before.conf
@@ -627,13 +627,15 @@ SecRule ARGS:route "@streq /sql" \
     ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query"
 
 # Mass actions on rows
-SecRule ARGS:route "@streq /table/change/rows" \
+SecRule ARGS:route "@rx ^/table/(?:change|delete)/(?:rows|confirm)$" \
     "id:9513660,\
     phase:1,\
     pass,\
     t:none,\
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetById=932105;ARGS,\
+    ctl:ruleRemoveTargetById=941100;ARGS,\
     ctl:ruleRemoveTargetById=942100;ARGS,\
     ctl:ruleRemoveTargetById=942110;ARGS,\
     ctl:ruleRemoveTargetById=942180;ARGS,\
@@ -641,8 +643,7 @@ SecRule ARGS:route "@streq /table/change/rows" \
     ctl:ruleRemoveTargetById=942380;ARGS,\
     ctl:ruleRemoveTargetById=942430;ARGS,\
     ctl:ruleRemoveTargetById=942480;ARGS,\
-    ctl:ruleRemoveTargetById=942510;ARGS,\
-    ctl:ruleRemoveTargetById=941100;ARGS"
+    ctl:ruleRemoveTargetById=942510;ARGS"
 
 # Opening custom SQL editor (general)
 SecRule ARGS:route "@streq /lint" \
@@ -964,5 +965,15 @@ SecRule ARGS:route "@streq /server/databases" \
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
     ctl:ruleRemoveTargetById=942140;ARGS:sort_by"
+
+# Ping?
+SecRule ARGS:route "@streq /" \
+    "id:9513910,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetById=942140;ARGS:db"
 
 SecMarker "END-PHPMYADMIN-RULE-EXCLUSIONS-PLUGIN-V51-URL-FORMAT"

--- a/plugins/phpmyadmin-rule-exclusions-before.conf
+++ b/plugins/phpmyadmin-rule-exclusions-before.conf
@@ -877,9 +877,50 @@ SecRule ARGS:route "@streq /database/qbe" \
     ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932115;ARGS:sql_query"
 
+# Databases -> Check privileges
+SecRule ARGS:route "@streq /server/privileges" \
+    "id:9513820,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetById=942140;ARGS:db,\
+    ctl:ruleRemoveTargetById=942140;ARGS:checkprivsdb"
+
+# Routines -> Add routine
+SecRule ARGS:route "@streq /database/routines" \
+    "id:9513830,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:item_definition"
+
+# Structure
+SecRule ARGS:route "@streq /database/structure" \
+    "id:9513840,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetById=942140;ARGS:db"
+
+# SQL (autocomplete in editor)
+SecRule ARGS:route "@streq /database/sql/autocomplete" \
+    "id:9513850,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetById=942140;ARGS:db"
+
 # Setup
 SecRule ARGS:route "@streq /config/set" \
-    "id:9513820,\
+    "id:9513860,\
     phase:1,\
     pass,\
     t:none,\
@@ -889,7 +930,7 @@ SecRule ARGS:route "@streq /config/set" \
 
 # Databases, sorting
 SecRule ARGS:route "@streq /server/databases" \
-    "id:9513830,\
+    "id:9513870,\
     phase:1,\
     pass,\
     t:none,\

--- a/plugins/phpmyadmin-rule-exclusions-before.conf
+++ b/plugins/phpmyadmin-rule-exclusions-before.conf
@@ -19,11 +19,33 @@
 # Generic rule to disable plugin
 SecRule TX:phpmyadmin-rule-exclusions-plugin_enabled "@eq 0" "id:9513099,phase:1,pass,nolog,ctl:ruleRemoveById=9513100-9513999"
 
-# Setup, same for both URL formats
+#
+# -=[ Cookies and setup (same for both URL formats) ]=-
+#
+
+# Session cookies whitelist + persistent cookies
+# These cookies may persist beyond sessions and may block a user when trying
+# to access phpMyAdmin for a second time.
+SecAction \
+    "id:9513100,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetById=941100;REQUEST_COOKIES,\
+    ctl:ruleRemoveTargetById=941120;REQUEST_COOKIES,\
+    ctl:ruleRemoveTargetById=942100;REQUEST_COOKIES:auto_saved_sql,\
+    ctl:ruleRemoveTargetById=942200;REQUEST_COOKIES:pmaAuth-1,\
+    ctl:ruleRemoveTargetById=942340;REQUEST_COOKIES:pmaAuth-1,\
+    ctl:ruleRemoveTargetById=942200;REQUEST_COOKIES:pmaUser-1,\
+    ctl:ruleRemoveTargetById=942340;REQUEST_COOKIES:pmaUser-1,\
+    ctl:ruleRemoveTargetById=942200;REQUEST_COOKIES:pma_console_config,\
+    ctl:ruleRemoveTargetById=942260;REQUEST_COOKIES:pma_console_config"
 
 # Setup - Overview
 SecRule REQUEST_FILENAME "@rx /setup/(?:index\.php)?$" \
-    "id:9513100,\
+    "id:9513110,\
     phase:1,\
     pass,\
     t:none,\
@@ -56,7 +78,7 @@ SecRule REQUEST_FILENAME "@rx /setup/(?:index\.php)?$" \
 
 # Setup - Export
 SecRule REQUEST_FILENAME "@endsWith /setup/config.php" \
-    "id:9513110,\
+    "id:9513120,\
     phase:1,\
     pass,\
     t:none,\
@@ -74,6 +96,19 @@ SecRule TX:PHPMYADMIN-RULE-EXCLUSIONS-PLUGIN_URL_FORMAT "@streq v51" \
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
     skipAfter:END-PHPMYADMIN-RULE-EXCLUSIONS-PLUGIN-OLD-URL-FORMAT"
+
+SecRule TX:PHPMYADMIN-RULE-EXCLUSIONS-PLUGIN_URL_FORMAT "@streq v51" \
+    "id:9513201,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
+    skipAfter:END-PHPMYADMIN-RULE-EXCLUSIONS-PLUGIN-OLD-URL-FORMAT"
+
+#
+# -=[ Old URL format (versions < 5.1) ]=-
+#
 
 # Editing / copying a row - loading row data
 SecRule REQUEST_FILENAME "@endsWith /tbl_change.php" \
@@ -327,29 +362,9 @@ SecRule REQUEST_FILENAME "@endsWith /error_report.php" \
     ctl:ruleRemoveTargetById=934100;ARGS,\
     ctl:ruleRemoveTargetById=942100;ARGS"
 
-# Session cookies allow list + persistent cookies
-# These cookies may persist beyond sessions and may block a user when trying
-# to access phpMyAdmin for a second time.
-SecAction \
-    "id:9513350,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
-    ctl:ruleRemoveTargetById=941100;REQUEST_COOKIES,\
-    ctl:ruleRemoveTargetById=941120;REQUEST_COOKIES,\
-    ctl:ruleRemoveTargetById=942100;REQUEST_COOKIES:auto_saved_sql,\
-    ctl:ruleRemoveTargetById=942200;REQUEST_COOKIES:pmaAuth-1,\
-    ctl:ruleRemoveTargetById=942340;REQUEST_COOKIES:pmaAuth-1,\
-    ctl:ruleRemoveTargetById=942200;REQUEST_COOKIES:pmaUser-1,\
-    ctl:ruleRemoveTargetById=942340;REQUEST_COOKIES:pmaUser-1,\
-    ctl:ruleRemoveTargetById=942200;REQUEST_COOKIES:pma_console_config,\
-    ctl:ruleRemoveTargetById=942260;REQUEST_COOKIES:pma_console_config"
-
 # Creating view
 SecRule REQUEST_FILENAME "@endsWith /view_create.php" \
-    "id:9513360,\
+    "id:9513350,\
     phase:1,\
     pass,\
     t:none,\
@@ -362,7 +377,7 @@ SecRule REQUEST_FILENAME "@endsWith /view_create.php" \
 # Search rows in a table
 # MySQL chars such as '%' trigger rules on ARGS:criteriaColumnTypes[n]
 SecRule REQUEST_FILENAME "@endsWith /tbl_select.php" \
-    "id:9513370,\
+    "id:9513360,\
     phase:1,\
     pass,\
     t:none,\
@@ -377,7 +392,7 @@ SecRule REQUEST_FILENAME "@endsWith /tbl_select.php" \
 # Column types contain SQL keyword. One commonly adds multiple columns.
 # The column types are in ARGS:field_type[n] and could get arbitrarily high.
 SecRule REQUEST_FILENAME "@endsWith /tbl_addfield.php" \
-    "id:9513380,\
+    "id:9513370,\
     phase:1,\
     pass,\
     t:none,\
@@ -390,7 +405,7 @@ SecRule REQUEST_FILENAME "@endsWith /tbl_addfield.php" \
 # Column types contain SQL keyword. One commonly adds multiple columns.
 # The column types are in ARGS:field_type[n] and ARGS:field_type_orig[n].
 SecRule REQUEST_FILENAME "@endsWith /tbl_structure.php" \
-    "id:9513390,\
+    "id:9513380,\
     phase:1,\
     pass,\
     t:none,\
@@ -403,7 +418,7 @@ SecRule REQUEST_FILENAME "@endsWith /tbl_structure.php" \
 
 # Query -> Multi-table query
 SecRule REQUEST_FILENAME "@endsWith /db_multi_table_query.php" \
-    "id:9513400,\
+    "id:9513390,\
     phase:1,\
     pass,\
     t:none,\
@@ -414,7 +429,7 @@ SecRule REQUEST_FILENAME "@endsWith /db_multi_table_query.php" \
 
 # Query -> Query by example
 SecRule REQUEST_FILENAME "@endsWith /db_qbe.php" \
-    "id:9513410,\
+    "id:9513400,\
     phase:1,\
     pass,\
     t:none,\
@@ -425,7 +440,7 @@ SecRule REQUEST_FILENAME "@endsWith /db_qbe.php" \
 
 # Databases -> Check privileges
 SecRule REQUEST_FILENAME "@endsWith /server_privileges.php" \
-    "id:9513420,\
+    "id:9513410,\
     phase:1,\
     pass,\
     t:none,\
@@ -436,7 +451,7 @@ SecRule REQUEST_FILENAME "@endsWith /server_privileges.php" \
 
 # Routines -> Add routine
 SecRule REQUEST_FILENAME "@endsWith /db_routines.php" \
-    "id:9513430,\
+    "id:9513420,\
     phase:1,\
     pass,\
     t:none,\
@@ -446,7 +461,7 @@ SecRule REQUEST_FILENAME "@endsWith /db_routines.php" \
 
 # Structure
 SecRule REQUEST_FILENAME "@endsWith /db_structure.php" \
-    "id:9513440,\
+    "id:9513430,\
     phase:1,\
     pass,\
     t:none,\
@@ -456,7 +471,7 @@ SecRule REQUEST_FILENAME "@endsWith /db_structure.php" \
 
 # SQL (autocomplete in editor)
 SecRule REQUEST_FILENAME "@endsWith /db_sql_autocomplete.php" \
-    "id:9513450,\
+    "id:9513440,\
     phase:1,\
     pass,\
     t:none,\
@@ -466,7 +481,7 @@ SecRule REQUEST_FILENAME "@endsWith /db_sql_autocomplete.php" \
 
 # Search - Find and replace
 SecRule REQUEST_FILENAME "@endsWith /tbl_find_replace.php" \
-    "id:9513460,\
+    "id:9513450,\
     phase:1,\
     pass,\
     t:none,\
@@ -476,7 +491,7 @@ SecRule REQUEST_FILENAME "@endsWith /tbl_find_replace.php" \
 
 # Search - Zoom search
 SecRule REQUEST_FILENAME "@endsWith /tbl_zoom_select.php" \
-    "id:9513470,\
+    "id:9513460,\
     phase:1,\
     pass,\
     t:none,\
@@ -486,7 +501,7 @@ SecRule REQUEST_FILENAME "@endsWith /tbl_zoom_select.php" \
 
 # Databases, sorting
 SecRule REQUEST_FILENAME "@endsWith /server_databases.php" \
-    "id:9513480,\
+    "id:9513470,\
     phase:1,\
     pass,\
     t:none,\
@@ -503,15 +518,33 @@ SecAction \
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
     skipAfter:END-PHPMYADMIN-RULE-EXCLUSIONS-PLUGIN-V51-URL-FORMAT"
 
+SecAction \
+    "id:9513601,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
+    skipAfter:END-PHPMYADMIN-RULE-EXCLUSIONS-PLUGIN-V51-URL-FORMAT"
+
 SecMarker "END-PHPMYADMIN-RULE-EXCLUSIONS-PLUGIN-OLD-URL-FORMAT"
 
-
-# Begin of v51 format rules
-
+#
+# -=[ New URL format (versions >= 5.1) ]=-
+#
 
 SecRule REQUEST_FILENAME "!@endsWith /index.php" \
     "id:9513610,\
     phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
+    skipAfter:END-PHPMYADMIN-RULE-EXCLUSIONS-PLUGIN-V51-URL-FORMAT"
+
+SecRule REQUEST_FILENAME "!@endsWith /index.php" \
+    "id:9513611,\
+    phase:2,\
     pass,\
     t:none,\
     nolog,\
@@ -644,7 +677,7 @@ SecRule ARGS:route "@streq /lint" \
 # Opening custom SQL editor (tables)
 SecRule ARGS:route "@streq /table/sql" \
     "id:9513680,\
-    phase:1,\
+    phase:2,\
     pass,\
     t:none,\
     nolog,\
@@ -863,25 +896,5 @@ SecRule ARGS:route "@streq /server/databases" \
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
     ctl:ruleRemoveTargetById=942140;ARGS:sort_by"
-
-# Session cookies whitelist + persistent cookies
-# These cookies may persist beyond sessions and may block a user when trying
-# to access phpMyAdmin for a second time.
-SecAction \
-    "id:9513840,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
-    ctl:ruleRemoveTargetById=941100;REQUEST_COOKIES,\
-    ctl:ruleRemoveTargetById=941120;REQUEST_COOKIES,\
-    ctl:ruleRemoveTargetById=942100;REQUEST_COOKIES:auto_saved_sql,\
-    ctl:ruleRemoveTargetById=942200;REQUEST_COOKIES:pmaAuth-1,\
-    ctl:ruleRemoveTargetById=942340;REQUEST_COOKIES:pmaAuth-1,\
-    ctl:ruleRemoveTargetById=942200;REQUEST_COOKIES:pmaUser-1,\
-    ctl:ruleRemoveTargetById=942340;REQUEST_COOKIES:pmaUser-1,\
-    ctl:ruleRemoveTargetById=942200;REQUEST_COOKIES:pma_console_config,\
-    ctl:ruleRemoveTargetById=942260;REQUEST_COOKIES:pma_console_config"
 
 SecMarker "END-PHPMYADMIN-RULE-EXCLUSIONS-PLUGIN-V51-URL-FORMAT"

--- a/plugins/phpmyadmin-rule-exclusions-before.conf
+++ b/plugins/phpmyadmin-rule-exclusions-before.conf
@@ -985,4 +985,13 @@ SecRule ARGS:route "@streq /" \
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
     ctl:ruleRemoveTargetById=942140;ARGS:db"
 
+SecRule ARGS:route "@streq /import/simulate-dml" \
+    "id:9513920,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetById=942350;ARGS:sql_query"
+
 SecMarker "END-PHPMYADMIN-RULE-EXCLUSIONS-PLUGIN-V51-URL-FORMAT"

--- a/plugins/phpmyadmin-rule-exclusions-before.conf
+++ b/plugins/phpmyadmin-rule-exclusions-before.conf
@@ -931,4 +931,14 @@ SecRule ARGS:route "@streq /server/variables" \
     ctl:ruleRemoveTargetById=951230;TX:sql_error_match,\
     ctl:ruleRemoveTargetById=951230;RESPONSE_BODY"
 
+SecRule ARGS:route "@streq /database/structure/empty-table" \
+    "id:9513890,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetById=951230;TX:sql_error_match,\
+    ctl:ruleRemoveTargetById=951230;RESPONSE_BODY"
+
 SecMarker "END-PHPMYADMIN-RULE-EXCLUSIONS-PLUGIN-V51-URL-FORMAT"

--- a/plugins/phpmyadmin-rule-exclusions-before.conf
+++ b/plugins/phpmyadmin-rule-exclusions-before.conf
@@ -281,6 +281,7 @@ SecRule REQUEST_FILENAME "@endsWith /import.php" \
     ctl:ruleRemoveById=200003,\
     ctl:ruleRemoveTargetById=951230;TX:sql_error_match,\
     ctl:ruleRemoveTargetById=951230;RESPONSE_BODY,\
+    ctl:ruleRemoveTargetById=953100;RESPONSE_BODY,\
     ctl:ruleRemoveTargetById=921110;REQUEST_BODY,\
     ctl:ruleRemoveTargetById=942110;ARGS:csv_enclosed,\
     ctl:ruleRemoveTargetById=942330;ARGS:csv_enclosed,\
@@ -708,6 +709,7 @@ SecRule ARGS:route "@streq /import" \
     ctl:ruleRemoveById=200003,\
     ctl:ruleRemoveTargetById=951230;TX:sql_error_match,\
     ctl:ruleRemoveTargetById=951230;RESPONSE_BODY,\
+    ctl:ruleRemoveTargetById=953100;RESPONSE_BODY,\
     ctl:ruleRemoveTargetById=921110;REQUEST_BODY,\
     ctl:ruleRemoveTargetById=942360;ARGS:dummy,\
     ctl:ruleRemoveTargetById=942110;ARGS:csv_enclosed,\

--- a/plugins/phpmyadmin-rule-exclusions-before.conf
+++ b/plugins/phpmyadmin-rule-exclusions-before.conf
@@ -199,6 +199,7 @@ SecRule REQUEST_FILENAME "@endsWith /tbl_row_action.php" \
     t:none,\
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetById=942100;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932105;ARGS,\
     ctl:ruleRemoveTargetById=941100;ARGS,\
     ctl:ruleRemoveTargetById=942100;ARGS,\
@@ -239,6 +240,7 @@ SecRule REQUEST_FILENAME "@endsWith /lint.php" \
     ctl:ruleRemoveTargetById=933160;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=933210;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=934100;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=942100;ARGS:sql_query,\
     ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
     ctl:ruleRemoveTargetByTag=attack-xss;ARGS:sql_query"
 
@@ -613,6 +615,7 @@ SecRule ARGS:route "@rx ^/table/(?:change|delete)/(?:rows|confirm)$" \
     t:none,\
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetById=942100;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932105;ARGS,\
     ctl:ruleRemoveTargetById=941100;ARGS,\
     ctl:ruleRemoveTargetById=942100;ARGS,\
@@ -653,6 +656,7 @@ SecRule ARGS:route "@streq /lint" \
     ctl:ruleRemoveTargetById=933160;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=933210;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=934100;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=942100;ARGS:sql_query,\
     ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
     ctl:ruleRemoveTargetByTag=attack-xss;ARGS:sql_query"
 

--- a/plugins/phpmyadmin-rule-exclusions-before.conf
+++ b/plugins/phpmyadmin-rule-exclusions-before.conf
@@ -322,7 +322,7 @@ SecRule REQUEST_FILENAME "@endsWith /db_events.php" \
 # Database export
 SecRule REQUEST_FILENAME "@endsWith /export.php" \
     "id:9513320,\
-    phase:1,\
+    phase:2,\
     pass,\
     t:none,\
     nolog,\
@@ -699,7 +699,7 @@ SecRule ARGS:route "@streq /database/sql" \
 # Importing data and executing of custom SQL
 SecRule ARGS:route "@streq /import" \
     "id:9513700,\
-    phase:1,\
+    phase:2,\
     pass,\
     t:none,\
     nolog,\
@@ -759,7 +759,7 @@ SecRule ARGS:route "@streq /database/events" \
     ctl:ruleRemoveTargetById=942350;ARGS:item_definition,\
     ctl:ruleRemoveTargetById=942360;ARGS:item_definition"
 
-# Database export
+# Database export - page renderer
 SecRule ARGS:route "@streq /database/export" \
     "id:9513730,\
     phase:1,\
@@ -774,19 +774,29 @@ SecRule ARGS:route "@streq /database/export" \
     ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=942140;ARGS:db"
 
-# Table export
-SecRule ARGS:route "@streq /table/export" \
+# Table export - page renderer
+SecRule ARGS:route "@rx ^/table/export(?:/rows)?$" \
     "id:9513740,\
-    phase:1,\
+    phase:2,\
     pass,\
     t:none,\
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
     ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query"
 
+# Export
+SecRule ARGS:route "@rx ^/export(?:/tables)?$" \
+    "id:9513750,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetById=942140;ARGS:db"
+
 # Sending error report
 SecRule ARGS:route "@streq /error-report" \
-    "id:9513750,\
+    "id:9513760,\
     phase:1,\
     pass,\
     t:none,\
@@ -799,7 +809,7 @@ SecRule ARGS:route "@streq /error-report" \
 
 # Creating view
 SecRule ARGS:route "@streq /view/create" \
-    "id:9513760,\
+    "id:9513770,\
     phase:1,\
     pass,\
     t:none,\
@@ -812,7 +822,7 @@ SecRule ARGS:route "@streq /view/create" \
 # Search rows in a table
 # MySQL chars such as '%' trigger rules on ARGS:criteriaColumnTypes[n]
 SecRule ARGS:route "@streq /table/search" \
-    "id:9513770,\
+    "id:9513780,\
     phase:1,\
     pass,\
     t:none,\
@@ -827,7 +837,7 @@ SecRule ARGS:route "@streq /table/search" \
 # Column types contain SQL keyword. One commonly adds multiple columns.
 # The column types are in ARGS:field_type[n] and could get arbitrarily high.
 SecRule ARGS:route "@streq /table/add-field" \
-    "id:9513780,\
+    "id:9513790,\
     phase:1,\
     pass,\
     t:none,\
@@ -840,7 +850,7 @@ SecRule ARGS:route "@streq /table/add-field" \
 # Column types contain SQL keyword. One commonly adds multiple columns.
 # The column types are in ARGS:field_type[n] and ARGS:field_type_orig[n].
 SecRule ARGS:route "@streq /table/structure/change" \
-    "id:9513790,\
+    "id:9513800,\
     phase:1,\
     pass,\
     t:none,\
@@ -853,7 +863,7 @@ SecRule ARGS:route "@streq /table/structure/change" \
 
 # Query -> Multi-table query
 SecRule ARGS:route "@streq /database/multi-table-query" \
-    "id:9513800,\
+    "id:9513810,\
     phase:1,\
     pass,\
     t:none,\
@@ -864,7 +874,7 @@ SecRule ARGS:route "@streq /database/multi-table-query" \
 
 # Query -> Query by example
 SecRule ARGS:route "@streq /database/qbe" \
-    "id:9513810,\
+    "id:9513820,\
     phase:1,\
     pass,\
     t:none,\
@@ -875,7 +885,7 @@ SecRule ARGS:route "@streq /database/qbe" \
 
 # Databases -> Check privileges
 SecRule ARGS:route "@streq /server/privileges" \
-    "id:9513820,\
+    "id:9513830,\
     phase:1,\
     pass,\
     t:none,\
@@ -886,7 +896,7 @@ SecRule ARGS:route "@streq /server/privileges" \
 
 # Routines -> Add routine
 SecRule ARGS:route "@streq /database/routines" \
-    "id:9513830,\
+    "id:9513840,\
     phase:1,\
     pass,\
     t:none,\
@@ -896,7 +906,7 @@ SecRule ARGS:route "@streq /database/routines" \
 
 # Structure
 SecRule ARGS:route "@streq /database/structure" \
-    "id:9513840,\
+    "id:9513850,\
     phase:1,\
     pass,\
     t:none,\
@@ -906,7 +916,7 @@ SecRule ARGS:route "@streq /database/structure" \
 
 # SQL (autocomplete in editor)
 SecRule ARGS:route "@streq /database/sql/autocomplete" \
-    "id:9513850,\
+    "id:9513860,\
     phase:1,\
     pass,\
     t:none,\
@@ -916,7 +926,7 @@ SecRule ARGS:route "@streq /database/sql/autocomplete" \
 
 # Search - Find and replace (table)
 SecRule ARGS:route "@streq /table/find-replace" \
-    "id:9513860,\
+    "id:9513870,\
     phase:1,\
     pass,\
     t:none,\
@@ -926,7 +936,7 @@ SecRule ARGS:route "@streq /table/find-replace" \
 
 # Search - Zoom search (table)
 SecRule ARGS:route "@streq /table/zoom-search" \
-    "id:9513870,\
+    "id:9513880,\
     phase:1,\
     pass,\
     t:none,\
@@ -936,7 +946,7 @@ SecRule ARGS:route "@streq /table/zoom-search" \
 
 # Setup
 SecRule ARGS:route "@streq /config/set" \
-    "id:9513880,\
+    "id:9513890,\
     phase:1,\
     pass,\
     t:none,\
@@ -946,7 +956,7 @@ SecRule ARGS:route "@streq /config/set" \
 
 # Databases, sorting
 SecRule ARGS:route "@streq /server/databases" \
-    "id:9513890,\
+    "id:9513900,\
     phase:1,\
     pass,\
     t:none,\

--- a/plugins/phpmyadmin-rule-exclusions-before.conf
+++ b/plugins/phpmyadmin-rule-exclusions-before.conf
@@ -707,6 +707,7 @@ SecRule ARGS:route "@streq /import" \
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
     ctl:ruleRemoveById=200003,\
     ctl:ruleRemoveTargetById=921110;REQUEST_BODY,\
+    ctl:ruleRemoveTargetById=942360;ARGS:dummy,\
     ctl:ruleRemoveTargetById=942110;ARGS:csv_enclosed,\
     ctl:ruleRemoveTargetById=942330;ARGS:csv_enclosed,\
     ctl:ruleRemoveTargetById=942110;ARGS:csv_escaped,\

--- a/plugins/phpmyadmin-rule-exclusions-before.conf
+++ b/plugins/phpmyadmin-rule-exclusions-before.conf
@@ -360,7 +360,7 @@ SecRule REQUEST_FILENAME "@endsWith /export.php" \
     ctl:ruleRemoveTargetById=932100;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932115;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=951210;TX:sql_error_match,\
-    ctl:ruleRemoveTargetById=951210;RESPONSE_BODY,\
+    ctl:ruleRemoveTargetById=951210;RESPONSE_BODY"
 
 # Table export
 SecRule REQUEST_FILENAME "@endsWith /tbl_export.php" \

--- a/plugins/phpmyadmin-rule-exclusions-before.conf
+++ b/plugins/phpmyadmin-rule-exclusions-before.conf
@@ -870,7 +870,7 @@ SecRule ARGS:route "@streq /table/add-field" \
 # Structure -> Change columns
 # Column types contain SQL keyword. One commonly adds multiple columns.
 # The column types are in ARGS:field_type[n] and ARGS:field_type_orig[n].
-SecRule ARGS:route "@streq /table/structure/change" \
+SecRule ARGS:route "@rx ^/table/structure/(?:save|change)$" \
     "id:9513800,\
     phase:1,\
     pass,\
@@ -879,6 +879,7 @@ SecRule ARGS:route "@streq /table/structure/change" \
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
     ctl:ruleRemoveTargetById=942190;ARGS,\
     ctl:ruleRemoveTargetById=942470;ARGS,\
+    ctl:ruleRemoveTargetById=942100;ARGS:field_extra_orig[0],\
     ctl:ruleRemoveTargetById=942100;ARGS:field_extra_orig[1]"
 
 # Query -> Multi-table query

--- a/plugins/phpmyadmin-rule-exclusions-before.conf
+++ b/plugins/phpmyadmin-rule-exclusions-before.conf
@@ -357,7 +357,9 @@ SecRule REQUEST_FILENAME "@endsWith /export.php" \
     ctl:ruleRemoveTargetById=942330;ARGS:csv_escaped,\
     ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932100;ARGS:sql_query,\
-    ctl:ruleRemoveTargetById=932115;ARGS:sql_query"
+    ctl:ruleRemoveTargetById=932115;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=951210;TX:sql_error_match,\
+    ctl:ruleRemoveTargetById=951210;RESPONSE_BODY,\
 
 # Table export
 SecRule REQUEST_FILENAME "@endsWith /tbl_export.php" \
@@ -782,7 +784,11 @@ SecRule ARGS:route "@streq /database/export" \
     ctl:ruleRemoveTargetById=942330;ARGS:csv_enclosed,\
     ctl:ruleRemoveTargetById=942110;ARGS:csv_escaped,\
     ctl:ruleRemoveTargetById=942330;ARGS:csv_escaped,\
-    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query"
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932100;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932115;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=951210;TX:sql_error_match,\
+    ctl:ruleRemoveTargetById=951210;RESPONSE_BODY,\
 
 # Table export - page renderer
 SecRule ARGS:route "@rx ^/table/export(?:/rows)?$" \

--- a/plugins/phpmyadmin-rule-exclusions-before.conf
+++ b/plugins/phpmyadmin-rule-exclusions-before.conf
@@ -189,7 +189,8 @@ SecRule REQUEST_FILENAME "@endsWith /sql.php" \
     ctl:ruleRemoveTargetById=942430;ARGS:goto,\
     ctl:ruleRemoveTargetById=942510;ARGS:goto,\
     ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
-    ctl:ruleRemoveTargetById=932115;ARGS:sql_query"
+    ctl:ruleRemoveTargetById=932115;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=933120;ARGS:sql_query"
 
 # Mass actions on rows
 SecRule REQUEST_FILENAME "@endsWith /tbl_row_action.php" \
@@ -241,6 +242,7 @@ SecRule REQUEST_FILENAME "@endsWith /lint.php" \
     ctl:ruleRemoveTargetById=933210;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=934100;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=942100;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=942360;ARGS:sql_query,\
     ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
     ctl:ruleRemoveTargetByTag=attack-xss;ARGS:sql_query"
 
@@ -312,7 +314,9 @@ SecRule REQUEST_FILENAME "@endsWith /import.php" \
     ctl:ruleRemoveTargetById=933150;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=933160;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=933210;ARGS:sql_query,\
-    ctl:ruleRemoveTargetById=934100;ARGS:sql_query"
+    ctl:ruleRemoveTargetById=934100;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=942100;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=942360;ARGS:sql_query"
 
 # Adding / editing triggers
 SecRule REQUEST_FILENAME "@endsWith /db_triggers.php" \
@@ -605,7 +609,8 @@ SecRule ARGS:route "@streq /sql" \
     ctl:ruleRemoveTargetById=942430;ARGS:goto,\
     ctl:ruleRemoveTargetById=942510;ARGS:goto,\
     ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
-    ctl:ruleRemoveTargetById=932115;ARGS:sql_query"
+    ctl:ruleRemoveTargetById=932115;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=933120;ARGS:sql_query"
 
 # Mass actions on rows
 SecRule ARGS:route "@rx ^/table/(?:change|delete)/(?:rows|confirm)$" \
@@ -657,6 +662,7 @@ SecRule ARGS:route "@streq /lint" \
     ctl:ruleRemoveTargetById=933210;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=934100;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=942100;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=942360;ARGS:sql_query,\
     ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
     ctl:ruleRemoveTargetByTag=attack-xss;ARGS:sql_query"
 
@@ -733,7 +739,9 @@ SecRule ARGS:route "@streq /import" \
     ctl:ruleRemoveTargetById=933150;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=933160;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=933210;ARGS:sql_query,\
-    ctl:ruleRemoveTargetById=934100;ARGS:sql_query"
+    ctl:ruleRemoveTargetById=934100;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=942100;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=942360;ARGS:sql_query"
 
 # Adding / editing triggers
 SecRule ARGS:route "@streq /database/triggers" \

--- a/plugins/phpmyadmin-rule-exclusions-before.conf
+++ b/plugins/phpmyadmin-rule-exclusions-before.conf
@@ -218,6 +218,7 @@ SecRule REQUEST_FILENAME "@endsWith /lint.php" \
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
     ctl:ruleRemoveTargetById=921110;REQUEST_BODY,\
     ctl:ruleRemoveTargetById=921110;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=921130;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932100;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932105;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932110;ARGS:sql_query,\
@@ -285,6 +286,7 @@ SecRule REQUEST_FILENAME "@endsWith /import.php" \
     ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
     ctl:ruleRemoveTargetByTag=attack-xss;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=921110;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=921130;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932100;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932105;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932110;ARGS:sql_query,\
@@ -619,6 +621,7 @@ SecRule ARGS:route "@streq /lint" \
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
     ctl:ruleRemoveTargetById=921110;REQUEST_BODY,\
     ctl:ruleRemoveTargetById=921110;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=921130;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932100;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932105;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932110;ARGS:sql_query,\
@@ -689,6 +692,7 @@ SecRule ARGS:route "@streq /import" \
     ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
     ctl:ruleRemoveTargetByTag=attack-xss;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=921110;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=921130;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932100;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932105;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932110;ARGS:sql_query,\

--- a/plugins/phpmyadmin-rule-exclusions-before.conf
+++ b/plugins/phpmyadmin-rule-exclusions-before.conf
@@ -42,7 +42,17 @@ SecRule REQUEST_FILENAME "@rx /setup/(?:index\.php)?$" \
     ctl:ruleRemoveTargetById=932120;ARGS_NAMES:Export-csv_null,\
     ctl:ruleRemoveTargetById=932120;ARGS_NAMES:Export-csv_null-userprefs-allow,\
     ctl:ruleRemoveTargetById=932120;ARGS_NAMES:Export-csv_removeCRLF-userprefs-allow,\
-    ctl:ruleRemoveTargetById=932120;ARGS_NAMES:Export-csv_columns-userprefs-allow"
+    ctl:ruleRemoveTargetById=932120;ARGS_NAMES:Export-csv_columns-userprefs-allow,\
+    ctl:ruleRemoveTargetById=932120;ARGS_NAMES:Import-csv_replace-userprefs-allow,\
+    ctl:ruleRemoveTargetById=932120;ARGS_NAMES:Import-csv_ignore-userprefs-allow,\
+    ctl:ruleRemoveTargetById=932120;ARGS_NAMES:Import-csv_terminated,\
+    ctl:ruleRemoveTargetById=932120;ARGS_NAMES:Import-csv_terminated-userprefs-allow,\
+    ctl:ruleRemoveTargetById=932120;ARGS_NAMES:Import-csv_enclosed,\
+    ctl:ruleRemoveTargetById=932120;ARGS_NAMES:Import-csv_enclosed-userprefs-allow,\
+    ctl:ruleRemoveTargetById=932120;ARGS_NAMES:Import-csv_escaped,\
+    ctl:ruleRemoveTargetById=932120;ARGS_NAMES:Import-csv_escaped-userprefs-allow,\
+    ctl:ruleRemoveTargetById=932120;ARGS_NAMES:Import-csv_col_names-userprefs-allow,\
+    ctl:ruleRemoveTargetById=932160;ARGS:DefaultTransformations-External"
 
 # Setup - Export
 SecRule REQUEST_FILENAME "@endsWith /setup/config.php" \

--- a/plugins/phpmyadmin-rule-exclusions-before.conf
+++ b/plugins/phpmyadmin-rule-exclusions-before.conf
@@ -216,6 +216,7 @@ SecRule REQUEST_FILENAME "@endsWith /lint.php" \
     ctl:ruleRemoveTargetById=921110;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932100;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932105;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932110;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932115;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932130;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932150;ARGS:sql_query,\
@@ -284,6 +285,7 @@ SecRule REQUEST_FILENAME "@endsWith /import.php" \
     ctl:ruleRemoveTargetById=921110;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932100;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932105;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932110;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932115;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932130;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932150;ARGS:sql_query,\
@@ -657,6 +659,7 @@ SecRule ARGS:route "@streq /lint" \
     ctl:ruleRemoveTargetById=921110;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932100;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932105;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932110;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932115;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932130;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932150;ARGS:sql_query,\
@@ -726,6 +729,7 @@ SecRule ARGS:route "@streq /import" \
     ctl:ruleRemoveTargetById=921110;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932100;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932105;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932110;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932115;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932130;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932150;ARGS:sql_query,\

--- a/plugins/phpmyadmin-rule-exclusions-before.conf
+++ b/plugins/phpmyadmin-rule-exclusions-before.conf
@@ -974,6 +974,7 @@ SecRule ARGS:route "@streq /database/sql/format" \
     t:none,\
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetById=932115;ARGS:sql,\
     ctl:ruleRemoveTargetById=942100;ARGS:sql,\
     ctl:ruleRemoveTargetById=942190;ARGS:sql,\
     ctl:ruleRemoveTargetById=942360;ARGS:sql"

--- a/plugins/phpmyadmin-rule-exclusions-before.conf
+++ b/plugins/phpmyadmin-rule-exclusions-before.conf
@@ -326,6 +326,8 @@ SecRule REQUEST_FILENAME "@endsWith /db_triggers.php" \
     t:none,\
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetById=921110;REQUEST_BODY,\
+    ctl:ruleRemoveTargetById=921110;ARGS:item_definition,\
     ctl:ruleRemoveTargetById=932115;ARGS:item_definition,\
     ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:item_definition"
 
@@ -751,6 +753,8 @@ SecRule ARGS:route "@streq /database/triggers" \
     t:none,\
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetById=921110;REQUEST_BODY,\
+    ctl:ruleRemoveTargetById=921110;ARGS:item_definition,\
     ctl:ruleRemoveTargetById=932115;ARGS:item_definition,\
     ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:item_definition"
 

--- a/plugins/phpmyadmin-rule-exclusions-before.conf
+++ b/plugins/phpmyadmin-rule-exclusions-before.conf
@@ -550,7 +550,7 @@ SecRule REQUEST_FILENAME "!@endsWith /index.php" \
 # Editing / copying a row - loading row data
 SecRule ARGS:route "@streq /table/change" \
     "id:9513620,\
-    phase:1,\
+    phase:2,\
     pass,\
     t:none,\
     nolog,\

--- a/plugins/phpmyadmin-rule-exclusions-before.conf
+++ b/plugins/phpmyadmin-rule-exclusions-before.conf
@@ -335,7 +335,8 @@ SecRule REQUEST_FILENAME "@endsWith /export.php" \
     ctl:ruleRemoveTargetById=942330;ARGS:csv_enclosed,\
     ctl:ruleRemoveTargetById=942110;ARGS:csv_escaped,\
     ctl:ruleRemoveTargetById=942330;ARGS:csv_escaped,\
-    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query"
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932100;ARGS:sql_query"
 
 # Table export
 SecRule REQUEST_FILENAME "@endsWith /tbl_export.php" \
@@ -745,7 +746,8 @@ SecRule ARGS:route "@rx ^/table/export(?:/rows)?$" \
     t:none,\
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
-    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query"
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932100;ARGS:sql_query"
 
 # Export
 SecRule ARGS:route "@rx ^/export(?:/tables)?$" \
@@ -755,7 +757,8 @@ SecRule ARGS:route "@rx ^/export(?:/tables)?$" \
     t:none,\
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
-    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query"
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932100;ARGS:sql_query"
 
 # Sending error report
 SecRule ARGS:route "@streq /error-report" \

--- a/plugins/phpmyadmin-rule-exclusions-before.conf
+++ b/plugins/phpmyadmin-rule-exclusions-before.conf
@@ -19,8 +19,33 @@
 # Generic rule to disable plugin
 SecRule TX:phpmyadmin-rule-exclusions-plugin_enabled "@eq 0" "id:9513099,phase:1,pass,nolog,ctl:ruleRemoveById=9513100-9513999"
 
-SecRule TX:PHPMYADMIN-RULE-EXCLUSIONS-PLUGIN_URL_FORMAT "@streq v51" \
+# Setup, same for both URL formats
+
+# Setup - Overview
+SecRule REQUEST_FILENAME "@rx /setup/(?:index\.php)?$" \
     "id:9513100,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetById=953110;RESPONSE_BODY,\
+    ctl:ruleRemoveTargetById=953110;TX:response_body_decompressed"
+
+# Setup - Export
+SecRule REQUEST_FILENAME "@endsWith /setup/config.php" \
+    "id:9513110,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetById=933100;ARGS:textconfig,\
+    ctl:ruleRemoveTargetById=953120;RESPONSE_BODY,\
+    ctl:ruleRemoveTargetById=953120;TX:response_body_decompressed"
+
+SecRule TX:PHPMYADMIN-RULE-EXCLUSIONS-PLUGIN_URL_FORMAT "@streq v51" \
+    "id:9513200,\
     phase:1,\
     pass,\
     t:none,\
@@ -30,7 +55,7 @@ SecRule TX:PHPMYADMIN-RULE-EXCLUSIONS-PLUGIN_URL_FORMAT "@streq v51" \
 
 # Editing / copying a row - loading row data
 SecRule REQUEST_FILENAME "@endsWith /tbl_change.php" \
-    "id:9513110,\
+    "id:9513210,\
     phase:1,\
     pass,\
     t:none,\
@@ -41,12 +66,13 @@ SecRule REQUEST_FILENAME "@endsWith /tbl_change.php" \
 
 # Editing / copying a row - saving row data
 SecRule REQUEST_FILENAME "@endsWith /tbl_replace.php" \
-    "id:9513120,\
+    "id:9513220,\
     phase:1,\
     pass,\
     t:none,\
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetById=921110;REQUEST_BODY,\
     ctl:ruleRemoveTargetById=920230;ARGS:err_url,\
     ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:err_url,\
     ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:where_clause[],\
@@ -66,7 +92,9 @@ SecRule REQUEST_FILENAME "@endsWith /tbl_replace.php" \
     ctl:ruleRemoveTargetById=933100;ARGS,\
     ctl:ruleRemoveTargetById=933120;ARGS,\
     ctl:ruleRemoveTargetById=933130;ARGS,\
+    ctl:ruleRemoveTargetById=933150;ARGS,\
     ctl:ruleRemoveTargetById=933160;ARGS,\
+    ctl:ruleRemoveTargetById=933210;ARGS,\
     ctl:ruleRemoveTargetById=934100;ARGS,\
     ctl:ruleRemoveTargetById=942100;ARGS,\
     ctl:ruleRemoveTargetById=942170;ARGS,\
@@ -78,7 +106,7 @@ SecRule REQUEST_FILENAME "@endsWith /tbl_replace.php" \
 
 # Downloading row data
 SecRule REQUEST_FILENAME "@endsWith /tbl_get_field.php" \
-    "id:9513130,\
+    "id:9513230,\
     phase:1,\
     pass,\
     t:none,\
@@ -89,7 +117,7 @@ SecRule REQUEST_FILENAME "@endsWith /tbl_get_field.php" \
 
 # Deleting a row
 SecRule REQUEST_FILENAME "@endsWith /sql.php" \
-    "id:9513140,\
+    "id:9513240,\
     phase:1,\
     pass,\
     t:none,\
@@ -106,7 +134,7 @@ SecRule REQUEST_FILENAME "@endsWith /sql.php" \
 
 # Mass actions on rows
 SecRule REQUEST_FILENAME "@endsWith /tbl_row_action.php" \
-    "id:9513150,\
+    "id:9513250,\
     phase:1,\
     pass,\
     t:none,\
@@ -125,7 +153,7 @@ SecRule REQUEST_FILENAME "@endsWith /tbl_row_action.php" \
 
 # Opening custom SQL editor (general)
 SecRule REQUEST_FILENAME "@endsWith /lint.php" \
-    "id:9513160,\
+    "id:9513260,\
     phase:1,\
     pass,\
     t:none,\
@@ -136,15 +164,22 @@ SecRule REQUEST_FILENAME "@endsWith /lint.php" \
     ctl:ruleRemoveTargetById=932100;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932105;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932115;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932130;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932150;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932160;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=933100;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=933120;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=933130;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=933150;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=933160;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=933210;ARGS:sql_query,\
-    ctl:ruleRemoveTargetById=941100;ARGS:sql_query,\
-    ctl:ruleRemoveTargetById=941310;ARGS:sql_query,\
-    ctl:ruleRemoveTargetById=941340;ARGS:sql_query,\
-    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query"
+    ctl:ruleRemoveTargetById=934100;ARGS:sql_query,\
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
+    ctl:ruleRemoveTargetByTag=attack-xss;ARGS:sql_query"
 
 # Opening custom SQL editor (tables)
 SecRule REQUEST_FILENAME "@endsWith /tbl_sql.php" \
-    "id:9513170,\
+    "id:9513270,\
     phase:1,\
     pass,\
     t:none,\
@@ -152,13 +187,14 @@ SecRule REQUEST_FILENAME "@endsWith /tbl_sql.php" \
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
     ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932100;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=933210;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=941100;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=941160;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=942140;ARGS:db"
 
 # Opening custom SQL editor (databases)
 SecRule REQUEST_FILENAME "@endsWith /db_sql.php" \
-    "id:9513180,\
+    "id:9513280,\
     phase:1,\
     pass,\
     t:none,\
@@ -169,7 +205,7 @@ SecRule REQUEST_FILENAME "@endsWith /db_sql.php" \
 
 # Importing data and executing of custom SQL
 SecRule REQUEST_FILENAME "@endsWith /import.php" \
-    "id:9513190,\
+    "id:9513290,\
     phase:1,\
     pass,\
     t:none,\
@@ -187,20 +223,28 @@ SecRule REQUEST_FILENAME "@endsWith /import.php" \
     ctl:ruleRemoveTargetById=942140;ARGS:db,\
     ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:prev_sql_query,\
     ctl:ruleRemoveTargetById=932130;ARGS:prev_sql_query,\
+    ctl:ruleRemoveTargetById=933210;ARGS:prev_sql_query,\
     ctl:ruleRemoveTargetById=942110;ARGS:sql_delimiter,\
     ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
+    ctl:ruleRemoveTargetByTag=attack-xss;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=921110;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932100;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932105;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932115;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932130;ARGS:sql_query,\
-    ctl:ruleRemoveTargetById=941100;ARGS:sql_query,\
-    ctl:ruleRemoveTargetById=941310;ARGS:sql_query,\
-    ctl:ruleRemoveTargetById=941340;ARGS:sql_query"
+    ctl:ruleRemoveTargetById=932150;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932160;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=933100;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=933120;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=933130;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=933150;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=933160;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=933210;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=934100;ARGS:sql_query"
 
 # Adding / editing triggers
 SecRule REQUEST_FILENAME "@endsWith /db_triggers.php" \
-    "id:9513200,\
+    "id:9513300,\
     phase:1,\
     pass,\
     t:none,\
@@ -211,7 +255,7 @@ SecRule REQUEST_FILENAME "@endsWith /db_triggers.php" \
 
 # Adding / editing events
 SecRule REQUEST_FILENAME "@endsWith /db_events.php" \
-    "id:9513210,\
+    "id:9513310,\
     phase:1,\
     pass,\
     t:none,\
@@ -222,7 +266,7 @@ SecRule REQUEST_FILENAME "@endsWith /db_events.php" \
 
 # Database export
 SecRule REQUEST_FILENAME "@endsWith /export.php" \
-    "id:9513220,\
+    "id:9513320,\
     phase:1,\
     pass,\
     t:none,\
@@ -236,7 +280,7 @@ SecRule REQUEST_FILENAME "@endsWith /export.php" \
 
 # Table export
 SecRule REQUEST_FILENAME "@endsWith /tbl_export.php" \
-    "id:9513230,\
+    "id:9513330,\
     phase:1,\
     pass,\
     t:none,\
@@ -247,7 +291,7 @@ SecRule REQUEST_FILENAME "@endsWith /tbl_export.php" \
 
 # Sending error report
 SecRule REQUEST_FILENAME "@endsWith /error_report.php" \
-    "id:9513240,\
+    "id:9513340,\
     phase:1,\
     pass,\
     t:none,\
@@ -262,7 +306,7 @@ SecRule REQUEST_FILENAME "@endsWith /error_report.php" \
 # These cookies may persist beyond sessions and may block a user when trying
 # to access phpMyAdmin for a second time.
 SecAction \
-    "id:9513250,\
+    "id:9513350,\
     phase:1,\
     pass,\
     t:none,\
@@ -280,7 +324,7 @@ SecAction \
 
 # Creating view
 SecRule REQUEST_FILENAME "@endsWith /view_create.php" \
-    "id:9513260,\
+    "id:9513360,\
     phase:1,\
     pass,\
     t:none,\
@@ -293,7 +337,7 @@ SecRule REQUEST_FILENAME "@endsWith /view_create.php" \
 # Search rows in a table
 # MySQL chars such as '%' trigger rules on ARGS:criteriaColumnTypes[n]
 SecRule REQUEST_FILENAME "@endsWith /tbl_select.php" \
-    "id:9513270,\
+    "id:9513370,\
     phase:1,\
     pass,\
     t:none,\
@@ -308,7 +352,7 @@ SecRule REQUEST_FILENAME "@endsWith /tbl_select.php" \
 # Column types contain SQL keyword. One commonly adds multiple columns.
 # The column types are in ARGS:field_type[n] and could get arbitrarily high.
 SecRule REQUEST_FILENAME "@endsWith /tbl_addfield.php" \
-    "id:9513280,\
+    "id:9513380,\
     phase:1,\
     pass,\
     t:none,\
@@ -321,7 +365,7 @@ SecRule REQUEST_FILENAME "@endsWith /tbl_addfield.php" \
 # Column types contain SQL keyword. One commonly adds multiple columns.
 # The column types are in ARGS:field_type[n] and ARGS:field_type_orig[n].
 SecRule REQUEST_FILENAME "@endsWith /tbl_structure.php" \
-    "id:9513290,\
+    "id:9513390,\
     phase:1,\
     pass,\
     t:none,\
@@ -333,7 +377,7 @@ SecRule REQUEST_FILENAME "@endsWith /tbl_structure.php" \
 
 # Query -> Multi-table query
 SecRule REQUEST_FILENAME "@endsWith /db_multi_table_query.php" \
-    "id:9513300,\
+    "id:9513400,\
     phase:1,\
     pass,\
     t:none,\
@@ -344,7 +388,7 @@ SecRule REQUEST_FILENAME "@endsWith /db_multi_table_query.php" \
 
 # Query -> Query by example
 SecRule REQUEST_FILENAME "@endsWith /db_qbe.php" \
-    "id:9513310,\
+    "id:9513410,\
     phase:1,\
     pass,\
     t:none,\
@@ -355,7 +399,7 @@ SecRule REQUEST_FILENAME "@endsWith /db_qbe.php" \
 
 # Databases -> Check privileges
 SecRule REQUEST_FILENAME "@endsWith /server_privileges.php" \
-    "id:9513320,\
+    "id:9513420,\
     phase:1,\
     pass,\
     t:none,\
@@ -366,7 +410,7 @@ SecRule REQUEST_FILENAME "@endsWith /server_privileges.php" \
 
 # Routines -> Add routine
 SecRule REQUEST_FILENAME "@endsWith /db_routines.php" \
-    "id:9513330,\
+    "id:9513430,\
     phase:1,\
     pass,\
     t:none,\
@@ -376,7 +420,7 @@ SecRule REQUEST_FILENAME "@endsWith /db_routines.php" \
 
 # Structure
 SecRule REQUEST_FILENAME "@endsWith /db_structure.php" \
-    "id:9513340,\
+    "id:9513440,\
     phase:1,\
     pass,\
     t:none,\
@@ -386,7 +430,7 @@ SecRule REQUEST_FILENAME "@endsWith /db_structure.php" \
 
 # SQL (autocomplete in editor)
 SecRule REQUEST_FILENAME "@endsWith /db_sql_autocomplete.php" \
-    "id:9513350,\
+    "id:9513450,\
     phase:1,\
     pass,\
     t:none,\
@@ -396,7 +440,7 @@ SecRule REQUEST_FILENAME "@endsWith /db_sql_autocomplete.php" \
 
 # Search - Find and replace
 SecRule REQUEST_FILENAME "@endsWith /tbl_find_replace.php" \
-    "id:9513360,\
+    "id:9513460,\
     phase:1,\
     pass,\
     t:none,\
@@ -406,7 +450,7 @@ SecRule REQUEST_FILENAME "@endsWith /tbl_find_replace.php" \
 
 # Search - Zoom search
 SecRule REQUEST_FILENAME "@endsWith /tbl_zoom_select.php" \
-    "id:9513370,\
+    "id:9513470,\
     phase:1,\
     pass,\
     t:none,\
@@ -414,14 +458,24 @@ SecRule REQUEST_FILENAME "@endsWith /tbl_zoom_select.php" \
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
     ctl:ruleRemoveTargetById=942140;ARGS:db"
 
-SecAction \
-    "id:9513500,\
+# Databases, sorting
+SecRule REQUEST_FILENAME "@endsWith /server_databases.php" \
+    "id:9513480,\
     phase:1,\
     pass,\
     t:none,\
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
-    skipAfter:END-PHPMYADMIN-RULE-EXCLUSIONS-PLUGIN-OLD-V51-FORMAT"
+    ctl:ruleRemoveTargetById=942140;ARGS:sort_by"
+
+SecAction \
+    "id:9513600,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
+    skipAfter:END-PHPMYADMIN-RULE-EXCLUSIONS-PLUGIN-V51-URL-FORMAT"
 
 SecMarker "END-PHPMYADMIN-RULE-EXCLUSIONS-PLUGIN-OLD-URL-FORMAT"
 
@@ -430,17 +484,17 @@ SecMarker "END-PHPMYADMIN-RULE-EXCLUSIONS-PLUGIN-OLD-URL-FORMAT"
 
 
 SecRule REQUEST_FILENAME "!@endsWith /index.php" \
-    "id:9513510,\
+    "id:9513610,\
     phase:1,\
     pass,\
     t:none,\
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
-    skipAfter:END-PHPMYADMIN-RULE-EXCLUSIONS-PLUGIN-OLD-V51-FORMAT"
+    skipAfter:END-PHPMYADMIN-RULE-EXCLUSIONS-PLUGIN-V51-URL-FORMAT"
 
 # Editing / copying a row - loading row data
 SecRule ARGS:route "@streq /table/change" \
-    "id:9513520,\
+    "id:9513620,\
     phase:1,\
     pass,\
     t:none,\
@@ -451,12 +505,13 @@ SecRule ARGS:route "@streq /table/change" \
 
 # Editing / copying a row - saving row data
 SecRule ARGS:route "@streq /table/replace" \
-    "id:9513530,\
+    "id:9513630,\
     phase:1,\
     pass,\
     t:none,\
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetById=921110;REQUEST_BODY,\
     ctl:ruleRemoveTargetById=920230;ARGS:err_url,\
     ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:err_url,\
     ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:where_clause[],\
@@ -476,7 +531,9 @@ SecRule ARGS:route "@streq /table/replace" \
     ctl:ruleRemoveTargetById=933100;ARGS,\
     ctl:ruleRemoveTargetById=933120;ARGS,\
     ctl:ruleRemoveTargetById=933130;ARGS,\
+    ctl:ruleRemoveTargetById=933150;ARGS,\
     ctl:ruleRemoveTargetById=933160;ARGS,\
+    ctl:ruleRemoveTargetById=933210;ARGS,\
     ctl:ruleRemoveTargetById=934100;ARGS,\
     ctl:ruleRemoveTargetById=942100;ARGS,\
     ctl:ruleRemoveTargetById=942170;ARGS,\
@@ -488,7 +545,7 @@ SecRule ARGS:route "@streq /table/replace" \
 
 # Downloading row data
 SecRule ARGS:route "@streq /table/get-field" \
-    "id:9513540,\
+    "id:9513640,\
     phase:1,\
     pass,\
     t:none,\
@@ -499,7 +556,7 @@ SecRule ARGS:route "@streq /table/get-field" \
 
 # Deleting a row
 SecRule ARGS:route "@streq /sql" \
-    "id:9513550,\
+    "id:9513650,\
     phase:1,\
     pass,\
     t:none,\
@@ -516,7 +573,7 @@ SecRule ARGS:route "@streq /sql" \
 
 # Mass actions on rows
 SecRule ARGS:route "@streq /table/change/rows" \
-    "id:9513560,\
+    "id:9513660,\
     phase:1,\
     pass,\
     t:none,\
@@ -534,7 +591,7 @@ SecRule ARGS:route "@streq /table/change/rows" \
 
 # Opening custom SQL editor (general)
 SecRule ARGS:route "@streq /lint" \
-    "id:9513570,\
+    "id:9513670,\
     phase:1,\
     pass,\
     t:none,\
@@ -545,25 +602,37 @@ SecRule ARGS:route "@streq /lint" \
     ctl:ruleRemoveTargetById=932100;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932105;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932115;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932130;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932150;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932160;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=933100;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=933120;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=933130;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=933150;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=933160;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=933210;ARGS:sql_query,\
-    ctl:ruleRemoveTargetById=941100;ARGS:sql_query,\
-    ctl:ruleRemoveTargetById=941310;ARGS:sql_query,\
-    ctl:ruleRemoveTargetById=941340;ARGS:sql_query,\
-    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query"
+    ctl:ruleRemoveTargetById=934100;ARGS:sql_query,\
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
+    ctl:ruleRemoveTargetByTag=attack-xss;ARGS:sql_query"
 
 # Opening custom SQL editor (tables)
 SecRule ARGS:route "@streq /table/sql" \
-    "id:9513580,\
+    "id:9513680,\
     phase:1,\
     pass,\
     t:none,\
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
-    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query"
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932100;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=933210;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=941100;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=941160;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=942140;ARGS:db"
 
 # Opening custom SQL editor (databases)
 SecRule ARGS:route "@streq /database/sql" \
-    "id:9513590,\
+    "id:9513690,\
     phase:1,\
     pass,\
     t:none,\
@@ -574,7 +643,7 @@ SecRule ARGS:route "@streq /database/sql" \
 
 # Importing data and executing of custom SQL
 SecRule ARGS:route "@streq /import" \
-    "id:9513600,\
+    "id:9513700,\
     phase:1,\
     pass,\
     t:none,\
@@ -592,20 +661,28 @@ SecRule ARGS:route "@streq /import" \
     ctl:ruleRemoveTargetById=942140;ARGS:db,\
     ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:prev_sql_query,\
     ctl:ruleRemoveTargetById=932130;ARGS:prev_sql_query,\
+    ctl:ruleRemoveTargetById=933210;ARGS:prev_sql_query,\
     ctl:ruleRemoveTargetById=942110;ARGS:sql_delimiter,\
     ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
+    ctl:ruleRemoveTargetByTag=attack-xss;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=921110;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932100;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932105;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932115;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932130;ARGS:sql_query,\
-    ctl:ruleRemoveTargetById=941100;ARGS:sql_query,\
-    ctl:ruleRemoveTargetById=941310;ARGS:sql_query,\
-    ctl:ruleRemoveTargetById=941340;ARGS:sql_query"
+    ctl:ruleRemoveTargetById=932150;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932160;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=933100;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=933120;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=933130;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=933150;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=933160;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=933210;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=934100;ARGS:sql_query"
 
 # Adding / editing triggers
 SecRule ARGS:route "@streq /database/triggers" \
-    "id:9513610,\
+    "id:9513710,\
     phase:1,\
     pass,\
     t:none,\
@@ -616,7 +693,7 @@ SecRule ARGS:route "@streq /database/triggers" \
 
 # Adding / editing events
 SecRule ARGS:route "@streq /database/events" \
-    "id:9513620,\
+    "id:9513720,\
     phase:1,\
     pass,\
     t:none,\
@@ -627,7 +704,7 @@ SecRule ARGS:route "@streq /database/events" \
 
 # Database export
 SecRule ARGS:route "@streq /database/export" \
-    "id:9513630,\
+    "id:9513730,\
     phase:1,\
     pass,\
     t:none,\
@@ -641,7 +718,7 @@ SecRule ARGS:route "@streq /database/export" \
 
 # Table export
 SecRule ARGS:route "@streq /table/export" \
-    "id:9513640,\
+    "id:9513740,\
     phase:1,\
     pass,\
     t:none,\
@@ -651,7 +728,7 @@ SecRule ARGS:route "@streq /table/export" \
 
 # Sending error report
 SecRule ARGS:route "@streq /error-report" \
-    "id:9513650,\
+    "id:9513750,\
     phase:1,\
     pass,\
     t:none,\
@@ -664,7 +741,7 @@ SecRule ARGS:route "@streq /error-report" \
 
 # Creating view
 SecRule ARGS:route "@streq /view/create" \
-    "id:9513660,\
+    "id:9513760,\
     phase:1,\
     pass,\
     t:none,\
@@ -677,7 +754,7 @@ SecRule ARGS:route "@streq /view/create" \
 # Search rows in a table
 # MySQL chars such as '%' trigger rules on ARGS:criteriaColumnTypes[n]
 SecRule ARGS:route "@streq /table/search" \
-    "id:9513670,\
+    "id:9513770,\
     phase:1,\
     pass,\
     t:none,\
@@ -692,7 +769,7 @@ SecRule ARGS:route "@streq /table/search" \
 # Column types contain SQL keyword. One commonly adds multiple columns.
 # The column types are in ARGS:field_type[n] and could get arbitrarily high.
 SecRule ARGS:route "@streq /table/add-field" \
-    "id:9513680,\
+    "id:9513780,\
     phase:1,\
     pass,\
     t:none,\
@@ -705,7 +782,7 @@ SecRule ARGS:route "@streq /table/add-field" \
 # Column types contain SQL keyword. One commonly adds multiple columns.
 # The column types are in ARGS:field_type[n] and ARGS:field_type_orig[n].
 SecRule ARGS:route "@streq /table/structure/change" \
-    "id:9513690,\
+    "id:9513790,\
     phase:1,\
     pass,\
     t:none,\
@@ -717,7 +794,7 @@ SecRule ARGS:route "@streq /table/structure/change" \
 
 # Query -> Multi-table query
 SecRule ARGS:route "@streq /database/multi-table-query" \
-    "id:9513700,\
+    "id:9513800,\
     phase:1,\
     pass,\
     t:none,\
@@ -728,7 +805,7 @@ SecRule ARGS:route "@streq /database/multi-table-query" \
 
 # Query -> Query by example
 SecRule ARGS:route "@streq /database/qbe" \
-    "id:9513710,\
+    "id:9513810,\
     phase:1,\
     pass,\
     t:none,\
@@ -739,7 +816,7 @@ SecRule ARGS:route "@streq /database/qbe" \
 
 # Setup
 SecRule ARGS:route "@streq /config/set" \
-    "id:9513720,\
+    "id:9513820,\
     phase:1,\
     pass,\
     t:none,\
@@ -751,7 +828,7 @@ SecRule ARGS:route "@streq /config/set" \
 # These cookies may persist beyond sessions and may block a user when trying
 # to access phpMyAdmin for a second time.
 SecAction \
-    "id:9513730,\
+    "id:9513830,\
     phase:1,\
     pass,\
     t:none,\
@@ -767,4 +844,4 @@ SecAction \
     ctl:ruleRemoveTargetById=942200;REQUEST_COOKIES:pma_console_config,\
     ctl:ruleRemoveTargetById=942260;REQUEST_COOKIES:pma_console_config"
 
-SecMarker "END-PHPMYADMIN-RULE-EXCLUSIONS-PLUGIN-OLD-V51-FORMAT"
+SecMarker "END-PHPMYADMIN-RULE-EXCLUSIONS-PLUGIN-V51-URL-FORMAT"

--- a/plugins/phpmyadmin-rule-exclusions-before.conf
+++ b/plugins/phpmyadmin-rule-exclusions-before.conf
@@ -908,6 +908,11 @@ SecRule ARGS:route "@streq /import/simulate-dml" \
     t:none,\
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
-    ctl:ruleRemoveTargetById=942350;ARGS:sql_query"
+    ctl:ruleRemoveTargetById=932115;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=941100;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=941160;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=941310;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=942350;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=942360;ARGS:sql_query"
 
 SecMarker "END-PHPMYADMIN-RULE-EXCLUSIONS-PLUGIN-V51-URL-FORMAT"

--- a/plugins/phpmyadmin-rule-exclusions-before.conf
+++ b/plugins/phpmyadmin-rule-exclusions-before.conf
@@ -183,7 +183,8 @@ SecRule REQUEST_FILENAME "@endsWith /sql.php" \
     ctl:ruleRemoveTargetById=942260;ARGS:goto,\
     ctl:ruleRemoveTargetById=942430;ARGS:goto,\
     ctl:ruleRemoveTargetById=942510;ARGS:goto,\
-    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query"
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932115;ARGS:sql_query"
 
 # Mass actions on rows
 SecRule REQUEST_FILENAME "@endsWith /tbl_row_action.php" \
@@ -626,7 +627,8 @@ SecRule ARGS:route "@streq /sql" \
     ctl:ruleRemoveTargetById=942260;ARGS:goto,\
     ctl:ruleRemoveTargetById=942430;ARGS:goto,\
     ctl:ruleRemoveTargetById=942510;ARGS:goto,\
-    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query"
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932115;ARGS:sql_query"
 
 # Mass actions on rows
 SecRule ARGS:route "@rx ^/table/(?:change|delete)/(?:rows|confirm)$" \

--- a/plugins/phpmyadmin-rule-exclusions-before.conf
+++ b/plugins/phpmyadmin-rule-exclusions-before.conf
@@ -824,11 +824,21 @@ SecRule ARGS:route "@streq /config/set" \
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
     ctl:ruleRemoveTargetById=942110;ARGS:value"
 
+# Databases, sorting
+SecRule ARGS:route "@streq /server/databases" \
+    "id:9513830,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetById=942140;ARGS:sort_by"
+
 # Session cookies whitelist + persistent cookies
 # These cookies may persist beyond sessions and may block a user when trying
 # to access phpMyAdmin for a second time.
 SecAction \
-    "id:9513830,\
+    "id:9513840,\
     phase:1,\
     pass,\
     t:none,\

--- a/plugins/phpmyadmin-rule-exclusions-before.conf
+++ b/plugins/phpmyadmin-rule-exclusions-before.conf
@@ -792,7 +792,8 @@ SecRule ARGS:route "@rx ^/export(?:/tables)?$" \
     t:none,\
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
-    ctl:ruleRemoveTargetById=942140;ARGS:db"
+    ctl:ruleRemoveTargetById=942140;ARGS:db,\
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query"
 
 # Sending error report
 SecRule ARGS:route "@streq /error-report" \

--- a/plugins/phpmyadmin-rule-exclusions-before.conf
+++ b/plugins/phpmyadmin-rule-exclusions-before.conf
@@ -899,7 +899,7 @@ SecRule ARGS:route "@streq /config/set" \
 
 # Databases, sorting
 SecRule ARGS:route "@streq /server/databases" \
-    "id:9513900,\
+    "id:9513860,\
     phase:1,\
     pass,\
     t:none,\
@@ -908,7 +908,7 @@ SecRule ARGS:route "@streq /server/databases" \
     ctl:ruleRemoveTargetById=942140;ARGS:sort_by"
 
 SecRule ARGS:route "@streq /import/simulate-dml" \
-    "id:9513910,\
+    "id:9513870,\
     phase:1,\
     pass,\
     t:none,\
@@ -920,5 +920,15 @@ SecRule ARGS:route "@streq /import/simulate-dml" \
     ctl:ruleRemoveTargetById=941310;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=942350;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=942360;ARGS:sql_query"
+
+SecRule ARGS:route "@streq /server/variables" \
+    "id:9513880,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetById=951230;TX:sql_error_match,\
+    ctl:ruleRemoveTargetById=951230;RESPONSE_BODY"
 
 SecMarker "END-PHPMYADMIN-RULE-EXCLUSIONS-PLUGIN-V51-URL-FORMAT"

--- a/plugins/phpmyadmin-rule-exclusions-before.conf
+++ b/plugins/phpmyadmin-rule-exclusions-before.conf
@@ -656,6 +656,8 @@ SecRule ARGS:route "@streq /table/sql" \
     t:none,\
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetById=951230;TX:sql_error_match,\
+    ctl:ruleRemoveTargetById=951230;RESPONSE_BODY,\
     ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932100;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932115;ARGS:sql_query,\

--- a/plugins/phpmyadmin-rule-exclusions-before.conf
+++ b/plugins/phpmyadmin-rule-exclusions-before.conf
@@ -221,6 +221,8 @@ SecRule REQUEST_FILENAME "@endsWith /lint.php" \
     ctl:ruleRemoveTargetById=921110;REQUEST_BODY,\
     ctl:ruleRemoveTargetById=921110;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=921130;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=930100;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=930110;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=930120;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932100;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932105;ARGS:sql_query,\
@@ -273,6 +275,8 @@ SecRule REQUEST_FILENAME "@endsWith /import.php" \
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
     ctl:ruleRemoveById=200003,\
+    ctl:ruleRemoveTargetById=951230;TX:sql_error_match,\
+    ctl:ruleRemoveTargetById=951230;RESPONSE_BODY,\
     ctl:ruleRemoveTargetById=921110;REQUEST_BODY,\
     ctl:ruleRemoveTargetById=942110;ARGS:csv_enclosed,\
     ctl:ruleRemoveTargetById=942330;ARGS:csv_enclosed,\
@@ -290,6 +294,8 @@ SecRule REQUEST_FILENAME "@endsWith /import.php" \
     ctl:ruleRemoveTargetByTag=attack-xss;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=921110;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=921130;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=930100;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=930110;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=930120;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932100;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932105;ARGS:sql_query,\
@@ -629,6 +635,8 @@ SecRule ARGS:route "@streq /lint" \
     ctl:ruleRemoveTargetById=921110;REQUEST_BODY,\
     ctl:ruleRemoveTargetById=921110;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=921130;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=930100;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=930110;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=930120;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932100;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932105;ARGS:sql_query,\
@@ -684,6 +692,8 @@ SecRule ARGS:route "@streq /import" \
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
     ctl:ruleRemoveById=200003,\
+    ctl:ruleRemoveTargetById=951230;TX:sql_error_match,\
+    ctl:ruleRemoveTargetById=951230;RESPONSE_BODY,\
     ctl:ruleRemoveTargetById=921110;REQUEST_BODY,\
     ctl:ruleRemoveTargetById=942360;ARGS:dummy,\
     ctl:ruleRemoveTargetById=942110;ARGS:csv_enclosed,\
@@ -703,6 +713,8 @@ SecRule ARGS:route "@streq /import" \
     ctl:ruleRemoveTargetByTag=attack-xss;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=921110;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=921130;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=930100;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=930110;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=930120;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932100;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932105;ARGS:sql_query,\

--- a/plugins/phpmyadmin-rule-exclusions-before.conf
+++ b/plugins/phpmyadmin-rule-exclusions-before.conf
@@ -19,315 +19,257 @@
 # Generic rule to disable plugin
 SecRule TX:phpmyadmin-rule-exclusions-plugin_enabled "@eq 0" "id:9513099,phase:1,pass,nolog,ctl:ruleRemoveById=9513100-9513999"
 
-
-# Editing / copying a row - loading row data
-SecRule REQUEST_FILENAME "@endsWith /tbl_change.php" \
+SecRule TX:PHPMYADMIN-RULE-EXCLUSIONS-PLUGIN_URL_FORMAT "@streq v51" \
     "id:9513100,\
     phase:1,\
     pass,\
     t:none,\
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
-    chain"
-    SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
-        "t:none,\
-        ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:where_clause,\
-        ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query"
+    skipAfter:END-PHPMYADMIN-RULE-EXCLUSIONS-PLUGIN-OLD-URL-FORMAT"
 
-# Editing / copying a row - saving row data
-SecRule REQUEST_FILENAME "@endsWith /tbl_replace.php" \
+# Editing / copying a row - loading row data
+SecRule REQUEST_FILENAME "@endsWith /tbl_change.php" \
     "id:9513110,\
     phase:1,\
     pass,\
     t:none,\
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
-    chain"
-    SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
-        "t:none,\
-        ctl:ruleRemoveTargetById=920230;ARGS:err_url,\
-        ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:err_url,\
-        ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:where_clause[],\
-        ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:where_clause[0],\
-        ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
-        ctl:ruleRemoveTargetByTag=attack-xss;ARGS,\
-        ctl:ruleRemoveTargetById=921110;ARGS,\
-        ctl:ruleRemoveTargetById=921130;ARGS,\
-        ctl:ruleRemoveTargetById=930120;ARGS,\
-        ctl:ruleRemoveTargetById=932100;ARGS,\
-        ctl:ruleRemoveTargetById=932105;ARGS,\
-        ctl:ruleRemoveTargetById=932110;ARGS,\
-        ctl:ruleRemoveTargetById=932115;ARGS,\
-        ctl:ruleRemoveTargetById=932130;ARGS,\
-        ctl:ruleRemoveTargetById=932140;ARGS,\
-        ctl:ruleRemoveTargetById=932150;ARGS,\
-        ctl:ruleRemoveTargetById=933100;ARGS,\
-        ctl:ruleRemoveTargetById=933120;ARGS,\
-        ctl:ruleRemoveTargetById=933130;ARGS,\
-        ctl:ruleRemoveTargetById=933160;ARGS,\
-        ctl:ruleRemoveTargetById=934100;ARGS,\
-        ctl:ruleRemoveTargetById=942100;ARGS,\
-        ctl:ruleRemoveTargetById=942170;ARGS,\
-        ctl:ruleRemoveTargetById=942190;ARGS,\
-        ctl:ruleRemoveTargetById=942230;ARGS,\
-        ctl:ruleRemoveTargetById=930100;ARGS:fields[multi_edit][0][],\
-        ctl:ruleRemoveTargetById=930110;ARGS:fields[multi_edit][0][],\
-        ctl:ruleRemoveTargetById=933210;ARGS:fields[multi_edit][0][]"
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:where_clause,\
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query"
 
-# Downloading row data
-SecRule REQUEST_FILENAME "@endsWith /tbl_get_field.php" \
+# Editing / copying a row - saving row data
+SecRule REQUEST_FILENAME "@endsWith /tbl_replace.php" \
     "id:9513120,\
     phase:1,\
     pass,\
     t:none,\
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
-    chain"
-    SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
-        "t:none,\
-        ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:where_clause,\
-        ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query"
+    ctl:ruleRemoveTargetById=920230;ARGS:err_url,\
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:err_url,\
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:where_clause[],\
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:where_clause[0],\
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
+    ctl:ruleRemoveTargetByTag=attack-xss;ARGS,\
+    ctl:ruleRemoveTargetById=921110;ARGS,\
+    ctl:ruleRemoveTargetById=921130;ARGS,\
+    ctl:ruleRemoveTargetById=930120;ARGS,\
+    ctl:ruleRemoveTargetById=932100;ARGS,\
+    ctl:ruleRemoveTargetById=932105;ARGS,\
+    ctl:ruleRemoveTargetById=932110;ARGS,\
+    ctl:ruleRemoveTargetById=932115;ARGS,\
+    ctl:ruleRemoveTargetById=932130;ARGS,\
+    ctl:ruleRemoveTargetById=932140;ARGS,\
+    ctl:ruleRemoveTargetById=932150;ARGS,\
+    ctl:ruleRemoveTargetById=933100;ARGS,\
+    ctl:ruleRemoveTargetById=933120;ARGS,\
+    ctl:ruleRemoveTargetById=933130;ARGS,\
+    ctl:ruleRemoveTargetById=933160;ARGS,\
+    ctl:ruleRemoveTargetById=934100;ARGS,\
+    ctl:ruleRemoveTargetById=942100;ARGS,\
+    ctl:ruleRemoveTargetById=942170;ARGS,\
+    ctl:ruleRemoveTargetById=942190;ARGS,\
+    ctl:ruleRemoveTargetById=942230;ARGS,\
+    ctl:ruleRemoveTargetById=930100;ARGS:fields[multi_edit][0][],\
+    ctl:ruleRemoveTargetById=930110;ARGS:fields[multi_edit][0][],\
+    ctl:ruleRemoveTargetById=933210;ARGS:fields[multi_edit][0][]"
 
-# Deleting a row
-SecRule REQUEST_FILENAME "@endsWith /sql.php" \
+# Downloading row data
+SecRule REQUEST_FILENAME "@endsWith /tbl_get_field.php" \
     "id:9513130,\
     phase:1,\
     pass,\
     t:none,\
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
-    chain"
-    SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
-        "t:none,\
-        ctl:ruleRemoveTargetById=942140;ARGS:db,\
-        ctl:ruleRemoveTargetById=920230;ARGS:goto,\
-        ctl:ruleRemoveTargetById=942100;ARGS:goto,\
-        ctl:ruleRemoveTargetById=942200;ARGS:goto,\
-        ctl:ruleRemoveTargetById=942260;ARGS:goto,\
-        ctl:ruleRemoveTargetById=942430;ARGS:goto,\
-        ctl:ruleRemoveTargetById=942510;ARGS:goto,\
-        ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query"
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:where_clause,\
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query"
 
-# Mass actions on rows
-SecRule REQUEST_FILENAME "@endsWith /tbl_row_action.php" \
+# Deleting a row
+SecRule REQUEST_FILENAME "@endsWith /sql.php" \
     "id:9513140,\
     phase:1,\
     pass,\
     t:none,\
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
-    chain"
-    SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
-        "t:none,\
-        ctl:ruleRemoveTargetById=932105;ARGS,\
-        ctl:ruleRemoveTargetById=941100;ARGS,\
-        ctl:ruleRemoveTargetById=942100;ARGS,\
-        ctl:ruleRemoveTargetById=942110;ARGS,\
-        ctl:ruleRemoveTargetById=942180;ARGS,\
-        ctl:ruleRemoveTargetById=942370;ARGS,\
-        ctl:ruleRemoveTargetById=942380;ARGS,\
-        ctl:ruleRemoveTargetById=942430;ARGS,\
-        ctl:ruleRemoveTargetById=942480;ARGS,\
-        ctl:ruleRemoveTargetById=942510;ARGS"
+    ctl:ruleRemoveTargetById=942140;ARGS:db,\
+    ctl:ruleRemoveTargetById=920230;ARGS:goto,\
+    ctl:ruleRemoveTargetById=942100;ARGS:goto,\
+    ctl:ruleRemoveTargetById=942200;ARGS:goto,\
+    ctl:ruleRemoveTargetById=942260;ARGS:goto,\
+    ctl:ruleRemoveTargetById=942430;ARGS:goto,\
+    ctl:ruleRemoveTargetById=942510;ARGS:goto,\
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query"
 
-# Opening custom SQL editor (general)
-SecRule REQUEST_FILENAME "@endsWith /lint.php" \
+# Mass actions on rows
+SecRule REQUEST_FILENAME "@endsWith /tbl_row_action.php" \
     "id:9513150,\
     phase:1,\
     pass,\
     t:none,\
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
-    chain"
-    SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
-        "t:none,\
-        ctl:ruleRemoveTargetById=921110;REQUEST_BODY,\
-        ctl:ruleRemoveTargetById=921110;ARGS:sql_query,\
-        ctl:ruleRemoveTargetById=932100;ARGS:sql_query,\
-        ctl:ruleRemoveTargetById=932105;ARGS:sql_query,\
-        ctl:ruleRemoveTargetById=932115;ARGS:sql_query,\
-        ctl:ruleRemoveTargetById=933210;ARGS:sql_query,\
-        ctl:ruleRemoveTargetById=941100;ARGS:sql_query,\
-        ctl:ruleRemoveTargetById=941310;ARGS:sql_query,\
-        ctl:ruleRemoveTargetById=941340;ARGS:sql_query,\
-        ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query"
+    ctl:ruleRemoveTargetById=932105;ARGS,\
+    ctl:ruleRemoveTargetById=941100;ARGS,\
+    ctl:ruleRemoveTargetById=942100;ARGS,\
+    ctl:ruleRemoveTargetById=942110;ARGS,\
+    ctl:ruleRemoveTargetById=942180;ARGS,\
+    ctl:ruleRemoveTargetById=942370;ARGS,\
+    ctl:ruleRemoveTargetById=942380;ARGS,\
+    ctl:ruleRemoveTargetById=942430;ARGS,\
+    ctl:ruleRemoveTargetById=942480;ARGS,\
+    ctl:ruleRemoveTargetById=942510;ARGS"
 
-# Opening custom SQL editor (tables)
-SecRule REQUEST_FILENAME "@endsWith /tbl_sql.php" \
+# Opening custom SQL editor (general)
+SecRule REQUEST_FILENAME "@endsWith /lint.php" \
     "id:9513160,\
     phase:1,\
     pass,\
     t:none,\
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
-    chain"
-    SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
-        "t:none,\
-        ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
-        ctl:ruleRemoveTargetById=932100;ARGS:sql_query,\
-        ctl:ruleRemoveTargetById=941100;ARGS:sql_query,\
-        ctl:ruleRemoveTargetById=941160;ARGS:sql_query,\
-        ctl:ruleRemoveTargetById=942140;ARGS:db"
+    ctl:ruleRemoveTargetById=921110;REQUEST_BODY,\
+    ctl:ruleRemoveTargetById=921110;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932100;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932105;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932115;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=933210;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=941100;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=941310;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=941340;ARGS:sql_query,\
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query"
 
-# Opening custom SQL editor (databases)
-SecRule REQUEST_FILENAME "@endsWith /db_sql.php" \
+# Opening custom SQL editor (tables)
+SecRule REQUEST_FILENAME "@endsWith /tbl_sql.php" \
     "id:9513170,\
     phase:1,\
     pass,\
     t:none,\
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
-    chain"
-    SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
-        "t:none,\
-        ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
-        ctl:ruleRemoveTargetById=942140;ARGS:db"
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932100;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=941100;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=941160;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=942140;ARGS:db"
 
-# Importing data and executing of custom SQL
-SecRule REQUEST_FILENAME "@endsWith /import.php" \
+# Opening custom SQL editor (databases)
+SecRule REQUEST_FILENAME "@endsWith /db_sql.php" \
     "id:9513180,\
     phase:1,\
     pass,\
     t:none,\
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
-    chain"
-    SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
-        "t:none,\
-        ctl:ruleRemoveById=200003,\
-        ctl:ruleRemoveTargetById=921110;REQUEST_BODY,\
-        ctl:ruleRemoveTargetById=942110;ARGS:csv_enclosed,\
-        ctl:ruleRemoveTargetById=942330;ARGS:csv_enclosed,\
-        ctl:ruleRemoveTargetById=942110;ARGS:csv_escaped,\
-        ctl:ruleRemoveTargetById=942330;ARGS:csv_escaped,\
-        ctl:ruleRemoveTargetById=942110;ARGS:ldi_enclosed,\
-        ctl:ruleRemoveTargetById=942330;ARGS:ldi_enclosed,\
-        ctl:ruleRemoveTargetById=942110;ARGS:ldi_terminated,\
-        ctl:ruleRemoveTargetById=942140;ARGS:db,\
-        ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:prev_sql_query,\
-        ctl:ruleRemoveTargetById=932130;ARGS:prev_sql_query,\
-        ctl:ruleRemoveTargetById=942110;ARGS:sql_delimiter,\
-        ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
-        ctl:ruleRemoveTargetById=921110;ARGS:sql_query,\
-        ctl:ruleRemoveTargetById=932100;ARGS:sql_query,\
-        ctl:ruleRemoveTargetById=932105;ARGS:sql_query,\
-        ctl:ruleRemoveTargetById=932115;ARGS:sql_query,\
-        ctl:ruleRemoveTargetById=932130;ARGS:sql_query,\
-        ctl:ruleRemoveTargetById=941100;ARGS:sql_query,\
-        ctl:ruleRemoveTargetById=941310;ARGS:sql_query,\
-        ctl:ruleRemoveTargetById=941340;ARGS:sql_query"
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=942140;ARGS:db"
 
-# Adding / editing triggers
-SecRule REQUEST_FILENAME "@endsWith /db_triggers.php" \
+# Importing data and executing of custom SQL
+SecRule REQUEST_FILENAME "@endsWith /import.php" \
     "id:9513190,\
     phase:1,\
     pass,\
     t:none,\
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
-    chain"
-    SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
-        "t:none,\
-        ctl:ruleRemoveTargetById=932115;ARGS:item_definition,\
-        ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:item_definition"
+    ctl:ruleRemoveById=200003,\
+    ctl:ruleRemoveTargetById=921110;REQUEST_BODY,\
+    ctl:ruleRemoveTargetById=942110;ARGS:csv_enclosed,\
+    ctl:ruleRemoveTargetById=942330;ARGS:csv_enclosed,\
+    ctl:ruleRemoveTargetById=942110;ARGS:csv_escaped,\
+    ctl:ruleRemoveTargetById=942330;ARGS:csv_escaped,\
+    ctl:ruleRemoveTargetById=942110;ARGS:ldi_enclosed,\
+    ctl:ruleRemoveTargetById=942330;ARGS:ldi_enclosed,\
+    ctl:ruleRemoveTargetById=942110;ARGS:ldi_terminated,\
+    ctl:ruleRemoveTargetById=942140;ARGS:db,\
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:prev_sql_query,\
+    ctl:ruleRemoveTargetById=932130;ARGS:prev_sql_query,\
+    ctl:ruleRemoveTargetById=942110;ARGS:sql_delimiter,\
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=921110;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932100;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932105;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932115;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932130;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=941100;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=941310;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=941340;ARGS:sql_query"
 
-# Adding / editing events
-SecRule REQUEST_FILENAME "@endsWith /db_events.php" \
+# Adding / editing triggers
+SecRule REQUEST_FILENAME "@endsWith /db_triggers.php" \
     "id:9513200,\
     phase:1,\
     pass,\
     t:none,\
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
-    chain"
-    SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
-        "t:none,\
-        ctl:ruleRemoveTargetById=932115;ARGS:item_definition,\
-        ctl:ruleRemoveTargetById=942350;ARGS:item_definition"
+    ctl:ruleRemoveTargetById=932115;ARGS:item_definition,\
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:item_definition"
 
-# Database export
-SecRule REQUEST_FILENAME "@endsWith /export.php" \
+# Adding / editing events
+SecRule REQUEST_FILENAME "@endsWith /db_events.php" \
     "id:9513210,\
     phase:1,\
     pass,\
     t:none,\
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
-    chain"
-    SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
-        "t:none,\
-        ctl:ruleRemoveTargetById=942110;ARGS:csv_enclosed,\
-        ctl:ruleRemoveTargetById=942330;ARGS:csv_enclosed,\
-        ctl:ruleRemoveTargetById=942110;ARGS:csv_escaped,\
-        ctl:ruleRemoveTargetById=942330;ARGS:csv_escaped,\
-        ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query"
+    ctl:ruleRemoveTargetById=932115;ARGS:item_definition,\
+    ctl:ruleRemoveTargetById=942350;ARGS:item_definition"
 
-# Table export
-SecRule REQUEST_FILENAME "@endsWith /tbl_export.php" \
+# Database export
+SecRule REQUEST_FILENAME "@endsWith /export.php" \
     "id:9513220,\
     phase:1,\
     pass,\
     t:none,\
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
-    chain"
-    SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
-        "t:none,\
-        ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
-        ctl:ruleRemoveTargetById=942140;ARGS:db"
+    ctl:ruleRemoveTargetById=942110;ARGS:csv_enclosed,\
+    ctl:ruleRemoveTargetById=942330;ARGS:csv_enclosed,\
+    ctl:ruleRemoveTargetById=942110;ARGS:csv_escaped,\
+    ctl:ruleRemoveTargetById=942330;ARGS:csv_escaped,\
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query"
 
-# Sending error report
-SecRule REQUEST_FILENAME "@endsWith /error_report.php" \
+# Table export
+SecRule REQUEST_FILENAME "@endsWith /tbl_export.php" \
     "id:9513230,\
     phase:1,\
     pass,\
     t:none,\
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
-    chain"
-    SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
-        "t:none,\
-        ctl:ruleRemoveTargetById=932130;ARGS,\
-        ctl:ruleRemoveTargetById=932140;ARGS,\
-        ctl:ruleRemoveTargetById=934100;ARGS,\
-        ctl:ruleRemoveTargetById=942100;ARGS"
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=942140;ARGS:db"
 
-# Session cookies allow list
-SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
+# Sending error report
+SecRule REQUEST_FILENAME "@endsWith /error_report.php" \
     "id:9513240,\
     phase:1,\
     pass,\
     t:none,\
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
-    ctl:ruleRemoveTargetById=941100;REQUEST_COOKIES,\
-    ctl:ruleRemoveTargetById=941120;REQUEST_COOKIES"
+    ctl:ruleRemoveTargetById=932130;ARGS,\
+    ctl:ruleRemoveTargetById=932140;ARGS,\
+    ctl:ruleRemoveTargetById=934100;ARGS,\
+    ctl:ruleRemoveTargetById=942100;ARGS"
 
-# Creating view
-SecRule REQUEST_FILENAME "@endsWith /view_create.php" \
+# Session cookies allow list + persistent cookies
+# These cookies may persist beyond sessions and may block a user when trying
+# to access phpMyAdmin for a second time.
+SecAction \
     "id:9513250,\
     phase:1,\
     pass,\
     t:none,\
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
-    chain"
-    SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
-        "t:none,\
-        ctl:ruleRemoveTargetById=941100;ARGS:view[as],\
-        ctl:ruleRemoveTargetById=942100;ARGS:view[as],\
-        ctl:ruleRemoveTargetById=942360;ARGS:view[as]"
-
-# Persistent cookies
-# These cookies may persist beyond sessions and may block a user when trying
-# to access phpMyAdmin for a second time.
-SecAction \
-    "id:9513260,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetById=941100;REQUEST_COOKIES,\
+    ctl:ruleRemoveTargetById=941120;REQUEST_COOKIES,\
     ctl:ruleRemoveTargetById=942100;REQUEST_COOKIES:auto_saved_sql,\
     ctl:ruleRemoveTargetById=942200;REQUEST_COOKIES:pmaAuth-1,\
     ctl:ruleRemoveTargetById=942340;REQUEST_COOKIES:pmaAuth-1,\
@@ -335,6 +277,18 @@ SecAction \
     ctl:ruleRemoveTargetById=942340;REQUEST_COOKIES:pmaUser-1,\
     ctl:ruleRemoveTargetById=942200;REQUEST_COOKIES:pma_console_config,\
     ctl:ruleRemoveTargetById=942260;REQUEST_COOKIES:pma_console_config"
+
+# Creating view
+SecRule REQUEST_FILENAME "@endsWith /view_create.php" \
+    "id:9513260,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetById=941100;ARGS:view[as],\
+    ctl:ruleRemoveTargetById=942100;ARGS:view[as],\
+    ctl:ruleRemoveTargetById=942360;ARGS:view[as]"
 
 # Search rows in a table
 # MySQL chars such as '%' trigger rules on ARGS:criteriaColumnTypes[n]
@@ -345,13 +299,10 @@ SecRule REQUEST_FILENAME "@endsWith /tbl_select.php" \
     t:none,\
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
-    chain"
-    SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
-        "t:none,\
-        ctl:ruleRemoveTargetById=942440;ARGS:orderByColumn,\
-        ctl:ruleRemoveTargetById=942470;ARGS,\
-        ctl:ruleRemoveTargetById=942300;ARGS,\
-        ctl:ruleRemoveTargetById=942140;ARGS:db"
+    ctl:ruleRemoveTargetById=942440;ARGS:orderByColumn,\
+    ctl:ruleRemoveTargetById=942470;ARGS,\
+    ctl:ruleRemoveTargetById=942300;ARGS,\
+    ctl:ruleRemoveTargetById=942140;ARGS:db"
 
 # Structure -> Add columns
 # Column types contain SQL keyword. One commonly adds multiple columns.
@@ -363,11 +314,8 @@ SecRule REQUEST_FILENAME "@endsWith /tbl_addfield.php" \
     t:none,\
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
-    chain"
-    SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
-        "t:none,\
-        ctl:ruleRemoveTargetById=942190;ARGS,\
-        ctl:ruleRemoveTargetById=942470;ARGS"
+    ctl:ruleRemoveTargetById=942190;ARGS,\
+    ctl:ruleRemoveTargetById=942470;ARGS"
 
 # Structure -> Change columns
 # Column types contain SQL keyword. One commonly adds multiple columns.
@@ -379,12 +327,9 @@ SecRule REQUEST_FILENAME "@endsWith /tbl_structure.php" \
     t:none,\
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
-    chain"
-    SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
-        "t:none,\
-        ctl:ruleRemoveTargetById=942190;ARGS,\
-        ctl:ruleRemoveTargetById=942470;ARGS,\
-        ctl:ruleRemoveTargetById=942140;ARGS:db"
+    ctl:ruleRemoveTargetById=942190;ARGS,\
+    ctl:ruleRemoveTargetById=942470;ARGS,\
+    ctl:ruleRemoveTargetById=942140;ARGS:db"
 
 # Query -> Multi-table query
 SecRule REQUEST_FILENAME "@endsWith /db_multi_table_query.php" \
@@ -394,11 +339,8 @@ SecRule REQUEST_FILENAME "@endsWith /db_multi_table_query.php" \
     t:none,\
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
-    chain"
-    SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
-        "t:none,\
-        ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
-        ctl:ruleRemoveTargetById=932115;ARGS:sql_query"
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932115;ARGS:sql_query"
 
 # Query -> Query by example
 SecRule REQUEST_FILENAME "@endsWith /db_qbe.php" \
@@ -408,11 +350,8 @@ SecRule REQUEST_FILENAME "@endsWith /db_qbe.php" \
     t:none,\
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
-    chain"
-    SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
-        "t:none,\
-        ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
-        ctl:ruleRemoveTargetById=932115;ARGS:sql_query"
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932115;ARGS:sql_query"
 
 # Databases -> Check privileges
 SecRule REQUEST_FILENAME "@endsWith /server_privileges.php" \
@@ -422,11 +361,8 @@ SecRule REQUEST_FILENAME "@endsWith /server_privileges.php" \
     t:none,\
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
-    chain"
-    SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
-        "t:none,\
-        ctl:ruleRemoveTargetById=942140;ARGS:db,\
-        ctl:ruleRemoveTargetById=942140;ARGS:checkprivsdb"
+    ctl:ruleRemoveTargetById=942140;ARGS:db,\
+    ctl:ruleRemoveTargetById=942140;ARGS:checkprivsdb"
 
 # Routines -> Add routine
 SecRule REQUEST_FILENAME "@endsWith /db_routines.php" \
@@ -436,10 +372,7 @@ SecRule REQUEST_FILENAME "@endsWith /db_routines.php" \
     t:none,\
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
-    chain"
-    SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
-        "t:none,\
-        ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:item_definition"
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:item_definition"
 
 # Structure
 SecRule REQUEST_FILENAME "@endsWith /db_structure.php" \
@@ -449,10 +382,7 @@ SecRule REQUEST_FILENAME "@endsWith /db_structure.php" \
     t:none,\
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
-    chain"
-    SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
-        "t:none,\
-        ctl:ruleRemoveTargetById=942140;ARGS:db"
+    ctl:ruleRemoveTargetById=942140;ARGS:db"
 
 # SQL (autocomplete in editor)
 SecRule REQUEST_FILENAME "@endsWith /db_sql_autocomplete.php" \
@@ -462,10 +392,7 @@ SecRule REQUEST_FILENAME "@endsWith /db_sql_autocomplete.php" \
     t:none,\
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
-    chain"
-    SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
-        "t:none,\
-        ctl:ruleRemoveTargetById=942140;ARGS:db"
+    ctl:ruleRemoveTargetById=942140;ARGS:db"
 
 # Search - Find and replace
 SecRule REQUEST_FILENAME "@endsWith /tbl_find_replace.php" \
@@ -475,10 +402,7 @@ SecRule REQUEST_FILENAME "@endsWith /tbl_find_replace.php" \
     t:none,\
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
-    chain"
-    SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
-        "t:none,\
-        ctl:ruleRemoveTargetById=942140;ARGS:db"
+    ctl:ruleRemoveTargetById=942140;ARGS:db"
 
 # Search - Zoom search
 SecRule REQUEST_FILENAME "@endsWith /tbl_zoom_select.php" \
@@ -488,7 +412,359 @@ SecRule REQUEST_FILENAME "@endsWith /tbl_zoom_select.php" \
     t:none,\
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
-    chain"
-    SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
-        "t:none,\
-        ctl:ruleRemoveTargetById=942140;ARGS:db"
+    ctl:ruleRemoveTargetById=942140;ARGS:db"
+
+SecAction \
+    "id:9513500,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
+    skipAfter:END-PHPMYADMIN-RULE-EXCLUSIONS-PLUGIN-OLD-V51-FORMAT"
+
+SecMarker "END-PHPMYADMIN-RULE-EXCLUSIONS-PLUGIN-OLD-URL-FORMAT"
+
+
+# Begin of v51 format rules
+
+
+SecRule REQUEST_FILENAME "!@endsWith /index.php" \
+    "id:9513510,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
+    skipAfter:END-PHPMYADMIN-RULE-EXCLUSIONS-PLUGIN-OLD-V51-FORMAT"
+
+# Editing / copying a row - loading row data
+SecRule ARGS:route "@streq /table/change" \
+    "id:9513520,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:where_clause,\
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query"
+
+# Editing / copying a row - saving row data
+SecRule ARGS:route "@streq /table/replace" \
+    "id:9513530,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetById=920230;ARGS:err_url,\
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:err_url,\
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:where_clause[],\
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:where_clause[0],\
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
+    ctl:ruleRemoveTargetByTag=attack-xss;ARGS,\
+    ctl:ruleRemoveTargetById=921110;ARGS,\
+    ctl:ruleRemoveTargetById=921130;ARGS,\
+    ctl:ruleRemoveTargetById=930120;ARGS,\
+    ctl:ruleRemoveTargetById=932100;ARGS,\
+    ctl:ruleRemoveTargetById=932105;ARGS,\
+    ctl:ruleRemoveTargetById=932110;ARGS,\
+    ctl:ruleRemoveTargetById=932115;ARGS,\
+    ctl:ruleRemoveTargetById=932130;ARGS,\
+    ctl:ruleRemoveTargetById=932140;ARGS,\
+    ctl:ruleRemoveTargetById=932150;ARGS,\
+    ctl:ruleRemoveTargetById=933100;ARGS,\
+    ctl:ruleRemoveTargetById=933120;ARGS,\
+    ctl:ruleRemoveTargetById=933130;ARGS,\
+    ctl:ruleRemoveTargetById=933160;ARGS,\
+    ctl:ruleRemoveTargetById=934100;ARGS,\
+    ctl:ruleRemoveTargetById=942100;ARGS,\
+    ctl:ruleRemoveTargetById=942170;ARGS,\
+    ctl:ruleRemoveTargetById=942190;ARGS,\
+    ctl:ruleRemoveTargetById=942230;ARGS,\
+    ctl:ruleRemoveTargetById=930100;ARGS:fields[multi_edit][0][],\
+    ctl:ruleRemoveTargetById=930110;ARGS:fields[multi_edit][0][],\
+    ctl:ruleRemoveTargetById=933210;ARGS:fields[multi_edit][0][]"
+
+# Downloading row data
+SecRule ARGS:route "@streq /table/get-field" \
+    "id:9513540,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:where_clause,\
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query"
+
+# Deleting a row
+SecRule ARGS:route "@streq /sql" \
+    "id:9513550,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetById=942140;ARGS:db,\
+    ctl:ruleRemoveTargetById=920230;ARGS:goto,\
+    ctl:ruleRemoveTargetById=942100;ARGS:goto,\
+    ctl:ruleRemoveTargetById=942200;ARGS:goto,\
+    ctl:ruleRemoveTargetById=942260;ARGS:goto,\
+    ctl:ruleRemoveTargetById=942430;ARGS:goto,\
+    ctl:ruleRemoveTargetById=942510;ARGS:goto,\
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query"
+
+# Mass actions on rows
+SecRule ARGS:route "@streq /table/change/rows" \
+    "id:9513560,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetById=942100;ARGS,\
+    ctl:ruleRemoveTargetById=942110;ARGS,\
+    ctl:ruleRemoveTargetById=942180;ARGS,\
+    ctl:ruleRemoveTargetById=942370;ARGS,\
+    ctl:ruleRemoveTargetById=942380;ARGS,\
+    ctl:ruleRemoveTargetById=942430;ARGS,\
+    ctl:ruleRemoveTargetById=942480;ARGS,\
+    ctl:ruleRemoveTargetById=942510;ARGS,\
+    ctl:ruleRemoveTargetById=941100;ARGS"
+
+# Opening custom SQL editor (general)
+SecRule ARGS:route "@streq /lint" \
+    "id:9513570,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetById=921110;REQUEST_BODY,\
+    ctl:ruleRemoveTargetById=921110;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932100;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932105;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932115;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=933210;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=941100;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=941310;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=941340;ARGS:sql_query,\
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query"
+
+# Opening custom SQL editor (tables)
+SecRule ARGS:route "@streq /table/sql" \
+    "id:9513580,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query"
+
+# Opening custom SQL editor (databases)
+SecRule ARGS:route "@streq /database/sql" \
+    "id:9513590,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=942140;ARGS:db"
+
+# Importing data and executing of custom SQL
+SecRule ARGS:route "@streq /import" \
+    "id:9513600,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveById=200003,\
+    ctl:ruleRemoveTargetById=921110;REQUEST_BODY,\
+    ctl:ruleRemoveTargetById=942110;ARGS:csv_enclosed,\
+    ctl:ruleRemoveTargetById=942330;ARGS:csv_enclosed,\
+    ctl:ruleRemoveTargetById=942110;ARGS:csv_escaped,\
+    ctl:ruleRemoveTargetById=942330;ARGS:csv_escaped,\
+    ctl:ruleRemoveTargetById=942110;ARGS:ldi_enclosed,\
+    ctl:ruleRemoveTargetById=942330;ARGS:ldi_enclosed,\
+    ctl:ruleRemoveTargetById=942110;ARGS:ldi_terminated,\
+    ctl:ruleRemoveTargetById=942140;ARGS:db,\
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:prev_sql_query,\
+    ctl:ruleRemoveTargetById=932130;ARGS:prev_sql_query,\
+    ctl:ruleRemoveTargetById=942110;ARGS:sql_delimiter,\
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=921110;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932100;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932105;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932115;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932130;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=941100;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=941310;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=941340;ARGS:sql_query"
+
+# Adding / editing triggers
+SecRule ARGS:route "@streq /database/triggers" \
+    "id:9513610,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetById=932115;ARGS:item_definition,\
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:item_definition"
+
+# Adding / editing events
+SecRule ARGS:route "@streq /database/events" \
+    "id:9513620,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetById=932115;ARGS:item_definition,\
+    ctl:ruleRemoveTargetById=942350;ARGS:item_definition"
+
+# Database export
+SecRule ARGS:route "@streq /database/export" \
+    "id:9513630,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetById=942110;ARGS:csv_enclosed,\
+    ctl:ruleRemoveTargetById=942330;ARGS:csv_enclosed,\
+    ctl:ruleRemoveTargetById=942110;ARGS:csv_escaped,\
+    ctl:ruleRemoveTargetById=942330;ARGS:csv_escaped,\
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query"
+
+# Table export
+SecRule ARGS:route "@streq /table/export" \
+    "id:9513640,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query"
+
+# Sending error report
+SecRule ARGS:route "@streq /error-report" \
+    "id:9513650,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetById=932130;ARGS,\
+    ctl:ruleRemoveTargetById=932140;ARGS,\
+    ctl:ruleRemoveTargetById=934100;ARGS,\
+    ctl:ruleRemoveTargetById=942100;ARGS"
+
+# Creating view
+SecRule ARGS:route "@streq /view/create" \
+    "id:9513660,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetById=941100;ARGS:view[as],\
+    ctl:ruleRemoveTargetById=942100;ARGS:view[as],\
+    ctl:ruleRemoveTargetById=942360;ARGS:view[as]"
+
+# Search rows in a table
+# MySQL chars such as '%' trigger rules on ARGS:criteriaColumnTypes[n]
+SecRule ARGS:route "@streq /table/search" \
+    "id:9513670,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetById=942440;ARGS:orderByColumn,\
+    ctl:ruleRemoveTargetById=942470;ARGS,\
+    ctl:ruleRemoveTargetById=942300;ARGS,\
+    ctl:ruleRemoveTargetById=942300;ARGS"
+
+# Structure -> Add columns
+# Column types contain SQL keyword. One commonly adds multiple columns.
+# The column types are in ARGS:field_type[n] and could get arbitrarily high.
+SecRule ARGS:route "@streq /table/add-field" \
+    "id:9513680,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetById=942190;ARGS,\
+    ctl:ruleRemoveTargetById=942470;ARGS"
+
+# Structure -> Change columns
+# Column types contain SQL keyword. One commonly adds multiple columns.
+# The column types are in ARGS:field_type[n] and ARGS:field_type_orig[n].
+SecRule ARGS:route "@streq /table/structure/change" \
+    "id:9513690,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetById=942190;ARGS,\
+    ctl:ruleRemoveTargetById=942470;ARGS,\
+    ctl:ruleRemoveTargetById=942140;ARGS:db"
+
+# Query -> Multi-table query
+SecRule ARGS:route "@streq /database/multi-table-query" \
+    "id:9513700,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932115;ARGS:sql_query"
+
+# Query -> Query by example
+SecRule ARGS:route "@streq /database/qbe" \
+    "id:9513710,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932115;ARGS:sql_query"
+
+# Setup
+SecRule ARGS:route "@streq /config/set" \
+    "id:9513720,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetById=942110;ARGS:value"
+
+# Session cookies whitelist + persistent cookies
+# These cookies may persist beyond sessions and may block a user when trying
+# to access phpMyAdmin for a second time.
+SecAction \
+    "id:9513730,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetById=941100;REQUEST_COOKIES,\
+    ctl:ruleRemoveTargetById=941120;REQUEST_COOKIES,\
+    ctl:ruleRemoveTargetById=942100;REQUEST_COOKIES:auto_saved_sql,\
+    ctl:ruleRemoveTargetById=942200;REQUEST_COOKIES:pmaAuth-1,\
+    ctl:ruleRemoveTargetById=942340;REQUEST_COOKIES:pmaAuth-1,\
+    ctl:ruleRemoveTargetById=942200;REQUEST_COOKIES:pmaUser-1,\
+    ctl:ruleRemoveTargetById=942340;REQUEST_COOKIES:pmaUser-1,\
+    ctl:ruleRemoveTargetById=942200;REQUEST_COOKIES:pma_console_config,\
+    ctl:ruleRemoveTargetById=942260;REQUEST_COOKIES:pma_console_config"
+
+SecMarker "END-PHPMYADMIN-RULE-EXCLUSIONS-PLUGIN-OLD-V51-FORMAT"

--- a/plugins/phpmyadmin-rule-exclusions-before.conf
+++ b/plugins/phpmyadmin-rule-exclusions-before.conf
@@ -684,6 +684,7 @@ SecRule ARGS:route "@streq /table/sql" \
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
     ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932100;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932115;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=933210;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=941100;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=941160;ARGS:sql_query,\
@@ -721,6 +722,7 @@ SecRule ARGS:route "@streq /import" \
     ctl:ruleRemoveTargetById=942140;ARGS:db,\
     ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:prev_sql_query,\
     ctl:ruleRemoveTargetById=932100;ARGS:prev_sql_query,\
+    ctl:ruleRemoveTargetById=932115;ARGS:prev_sql_query,\
     ctl:ruleRemoveTargetById=932130;ARGS:prev_sql_query,\
     ctl:ruleRemoveTargetById=933210;ARGS:prev_sql_query,\
     ctl:ruleRemoveTargetById=942110;ARGS:sql_delimiter,\

--- a/plugins/phpmyadmin-rule-exclusions-config.conf
+++ b/plugins/phpmyadmin-rule-exclusions-config.conf
@@ -1,6 +1,6 @@
 # ------------------------------------------------------------------------
 # OWASP ModSecurity Core Rule Set Plugin
-# Copyright (c) 2021-2022 Core Rule Set project. All rights reserved.
+# Copyright (c) 2021-2023 Core Rule Set project. All rights reserved.
 #
 # The OWASP ModSecurity Core Rule Set plugins are distributed under
 # Apache Software License (ASL) version 2

--- a/plugins/phpmyadmin-rule-exclusions-config.conf
+++ b/plugins/phpmyadmin-rule-exclusions-config.conf
@@ -41,3 +41,12 @@
 #   pass,\
 #   nolog,\
 #   setvar:'tx.phpmyadmin-rule-exclusions-plugin_enabled=0'"
+
+SecAction \
+ "id:9513020,\
+  phase:1,\
+  nolog,\
+  pass,\
+  t:none,\
+  ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
+  setvar:'tx.phpmyadmin-rule-exclusions-plugin_url_format=v51'"


### PR DESCRIPTION
Changes in this PR:
 - configurable support for old and new URL format
 - removed check for PMA cookies existance as it's no longer needed (plugin should be activated only on vhosts where PMA is running, not globally)
 - renumbering IDs (as a consequnce of changes above)