### PR TITLE
fix: fixing FPs

### DIFF
--- a/plugins/phpmyadmin-rule-exclusions-before.conf
+++ b/plugins/phpmyadmin-rule-exclusions-before.conf
@@ -189,6 +189,8 @@ SecRule REQUEST_FILENAME "@endsWith /sql.php" \
     ctl:ruleRemoveTargetById=953100;RESPONSE_BODY,\
     ctl:ruleRemoveTargetById=920230;ARGS:goto,\
     ctl:ruleRemoveTargetById=942100;ARGS:goto,\
+    ctl:ruleRemoveTargetById=942140;ARGS:goto,\
+    ctl:ruleRemoveTargetById=942190;ARGS:goto,\
     ctl:ruleRemoveTargetById=942200;ARGS:goto,\
     ctl:ruleRemoveTargetById=942260;ARGS:goto,\
     ctl:ruleRemoveTargetById=942430;ARGS:goto,\
@@ -622,6 +624,8 @@ SecRule ARGS:route "@streq /sql" \
     ctl:ruleRemoveTargetById=953100;RESPONSE_BODY,\
     ctl:ruleRemoveTargetById=920230;ARGS:goto,\
     ctl:ruleRemoveTargetById=942100;ARGS:goto,\
+    ctl:ruleRemoveTargetById=942140;ARGS:goto,\
+    ctl:ruleRemoveTargetById=942190;ARGS:goto,\
     ctl:ruleRemoveTargetById=942200;ARGS:goto,\
     ctl:ruleRemoveTargetById=942260;ARGS:goto,\
     ctl:ruleRemoveTargetById=942430;ARGS:goto,\


### PR DESCRIPTION
Parameter `goto` indicates where the user should be redirected after doing some action. Example of value doing FP:

`goto=index.php?route=/sql&db=INFORMATION_SCHEMA&table=VIEWS&sql_query=select+VIEW_DEFINITION+%0D%0Afrom+INFORMATION_SCHEMA.VIEWS%0D%0Awhere+TABLE_NAME+%3D+%27wp_wpdatatable_14%27%3B&server=3`