### PR TITLE
fix: false positive when changing table structure

### DIFF
--- a/plugins/phpmyadmin-rule-exclusions-before.conf
+++ b/plugins/phpmyadmin-rule-exclusions-before.conf
@@ -921,6 +921,8 @@ SecRule ARGS:route "@rx ^/table/structure/(?:save|change)$" \
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
     ctl:ruleRemoveTargetById=942190;ARGS,\
     ctl:ruleRemoveTargetById=942470;ARGS,\
+    ctl:ruleRemoveTargetById=942100;ARGS:field_expression_orig[2],\
+    ctl:ruleRemoveTargetById=942100;ARGS:field_expression[2],\
     ctl:ruleRemoveTargetById=942100;ARGS:field_extra_orig[0],\
     ctl:ruleRemoveTargetById=942100;ARGS:field_extra_orig[1]"
 

--- a/tests/regression/phpmyadmin-plugin/9513800.yaml
+++ b/tests/regression/phpmyadmin-plugin/9513800.yaml
@@ -1,0 +1,43 @@
+---
+meta:
+  author: "azurit"
+  description: "Test PhpMyAdmin Plugin"
+  enabled: true
+  name: 9513800.yaml
+tests:
+  - test_title: 9513800-1
+    desc: Check FPs when changing table structure
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: "OWASP CRS test agent"
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Cookie: phpMyAdmin=1
+            port: 80
+            method: POST
+            version: HTTP/1.1
+            uri: /post/index.php?route=/table/structure/save
+            data: field_expression_orig[2]=concat(`first_name`,' ',`last_name`)
+          output:
+            no_log_contains: id "942100"
+  - test_title: 9513800-2
+    desc: Check FPs when changing table structure 2
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: "OWASP CRS test agent"
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Cookie: phpMyAdmin=1
+            port: 80
+            method: POST
+            version: HTTP/1.1
+            uri: /post/index.php?route=/table/structure/save
+            data: field_expression[2]=concat(`first_name`,' ',`last_name`)
+          output:
+            no_log_contains: id "942100"


### PR DESCRIPTION
Fixing FP with these values:
```
field_expression_orig[2]=concat(`first_name`,' ',`last_name`)
field_expression[2]=concat(`first_name`,' ',`last_name`)
```