### PR TITLE
fix: FP when viewing mysql db

### DIFF
--- a/plugins/phpmyadmin-rule-exclusions-before.conf
+++ b/plugins/phpmyadmin-rule-exclusions-before.conf
@@ -26,8 +26,9 @@ SecRule TX:phpmyadmin-rule-exclusions-plugin_enabled "@eq 0" "id:9513099,phase:1
 # Session cookies whitelist + persistent cookies
 # These cookies may persist beyond sessions and may block a user when trying
 # to access phpMyAdmin for a second time.
-# Rule 942140 is disabled for "db" argument because of the "information_schema"
-# keyword.
+# Rules 932260 and 942140 are disabled for the "db" argument because the
+# "mysql" keyword triggers for the former and "information_schema" keyword
+# for the latter.
 # Operator @unconditionalMatch is used instead of a SecAction because of a bug
 # in ModSecurity v3 which prevents SecActions to be removed using ctl action.
 SecRule REQUEST_FILENAME "@unconditionalMatch" \
@@ -37,6 +38,7 @@ SecRule REQUEST_FILENAME "@unconditionalMatch" \
     t:none,\
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetById=932260;ARGS:db,\
     ctl:ruleRemoveTargetById=942140;ARGS:db,\
     ctl:ruleRemoveTargetById=932200;REQUEST_COOKIES,\
     ctl:ruleRemoveTargetById=941100;REQUEST_COOKIES,\


### PR DESCRIPTION
Updated to latest CRS and noticed a FP when selecting the "mysql" database in the left hand navigation.
This change resolves the issue. Tested with phpMyAdmin 5.2.2

For reference:
`[file "/usr/share/modsecurity-crs/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf"] [line "538"] [id "932260"] [msg "Remote Command Execution: Direct Unix Command Execution"] [data "Matched Data: mysql found within ARGS:db: mysql"] [severity "CRITICAL"] [ver "OWASP_CRS/4.12.0-dev"] [tag "application-multi"] [tag "language-shell"] [tag "platform-unix"] [tag "attack-rce"] [tag "paranoia-level/1"] [tag "OWASP_CRS"] [tag "capec/1000/152/248/88"] [tag "PCI/6.5.2"] [hostname "xxx.xxx.xxx.xxx"] [uri "/index.php"] [unique_id "Z7tmdxK4fZKXaOSeYTMh_wAAAAA"], referer: http://xxx.xxx.xxx.xxx:8070/index.php?route=/database/structure&db=information_schema`