### PR TITLE
fix: FPs in SQL query on multiple places

### DIFF
--- a/plugins/phpmyadmin-rule-exclusions-before.conf
+++ b/plugins/phpmyadmin-rule-exclusions-before.conf
@@ -1083,4 +1083,12 @@ SecRule ARGS:route "@streq /" \
     ctl:ruleRemoveTargetById=951220;RESPONSE_BODY,\
     ctl:ruleRemoveTargetById=953100;RESPONSE_BODY"
 
+SecRule ARGS:route "@streq /preferences/features" \
+    "id:9513920,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ctl:ruleRemoveTargetById=951210;RESPONSE_BODY"
+
 SecMarker "END-PHPMYADMIN-RULE-EXCLUSIONS-PLUGIN-V51-URL-FORMAT"

--- a/plugins/phpmyadmin-rule-exclusions-before.conf
+++ b/plugins/phpmyadmin-rule-exclusions-before.conf
@@ -40,6 +40,7 @@ SecRule REQUEST_FILENAME "@unconditionalMatch" \
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
     ctl:ruleRemoveTargetById=932260;ARGS:db,\
     ctl:ruleRemoveTargetById=942140;ARGS:db,\
+    ctl:ruleRemoveTargetById=921140;REQUEST_HEADERS:Referer,\
     ctl:ruleRemoveTargetById=942100;REQUEST_HEADERS:Referer,\
     ctl:ruleRemoveTargetById=932200;REQUEST_COOKIES,\
     ctl:ruleRemoveTargetById=941100;REQUEST_COOKIES,\

--- a/plugins/phpmyadmin-rule-exclusions-before.conf
+++ b/plugins/phpmyadmin-rule-exclusions-before.conf
@@ -193,6 +193,7 @@ SecRule REQUEST_FILENAME "@endsWith /tbl_get_field.php" \
     ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query"
 
 # Deleting a row
+# Keep in sync with rule 9513650.
 SecRule REQUEST_FILENAME "@endsWith /sql.php" \
     "id:9513240,\
     phase:1,\
@@ -212,6 +213,7 @@ SecRule REQUEST_FILENAME "@endsWith /sql.php" \
     ctl:ruleRemoveTargetById=942510;ARGS:goto,\
     ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932115;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932370;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932380;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=933120;ARGS:sql_query"
 
@@ -341,6 +343,7 @@ SecRule REQUEST_FILENAME "@endsWith /import.php" \
     ctl:ruleRemoveTargetById=932105;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932110;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932115;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932125;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932130;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932140;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932150;ARGS:sql_query,\
@@ -640,6 +643,7 @@ SecRule ARGS:route "@streq /table/get-field" \
     ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query"
 
 # Deleting a row
+# Keep in sync with rule 9513240.
 SecRule ARGS:route "@streq /sql" \
     "id:9513650,\
     phase:2,\
@@ -659,6 +663,7 @@ SecRule ARGS:route "@streq /sql" \
     ctl:ruleRemoveTargetById=942510;ARGS:goto,\
     ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932115;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932370;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932380;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=933120;ARGS:sql_query"
 
@@ -790,6 +795,7 @@ SecRule ARGS:route "@streq /import" \
     ctl:ruleRemoveTargetById=932105;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932110;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932115;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932125;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932130;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932150;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932140;ARGS:sql_query,\

--- a/plugins/phpmyadmin-rule-exclusions-before.conf
+++ b/plugins/phpmyadmin-rule-exclusions-before.conf
@@ -254,6 +254,7 @@ SecRule REQUEST_FILENAME "@endsWith /lint.php" \
     ctl:ruleRemoveTargetById=932105;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932110;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932115;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932125;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932130;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932140;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932150;ARGS:sql_query,\
@@ -700,6 +701,7 @@ SecRule ARGS:route "@streq /lint" \
     ctl:ruleRemoveTargetById=932105;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932110;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932115;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932125;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932130;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932140;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932150;ARGS:sql_query,\

--- a/plugins/phpmyadmin-rule-exclusions-before.conf
+++ b/plugins/phpmyadmin-rule-exclusions-before.conf
@@ -40,6 +40,7 @@ SecRule REQUEST_FILENAME "@unconditionalMatch" \
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
     ctl:ruleRemoveTargetById=932260;ARGS:db,\
     ctl:ruleRemoveTargetById=942140;ARGS:db,\
+    ctl:ruleRemoveTargetById=942100;REQUEST_HEADERS:Referer,\
     ctl:ruleRemoveTargetById=932200;REQUEST_COOKIES,\
     ctl:ruleRemoveTargetById=941100;REQUEST_COOKIES,\
     ctl:ruleRemoveTargetById=941120;REQUEST_COOKIES,\

--- a/plugins/phpmyadmin-rule-exclusions-before.conf
+++ b/plugins/phpmyadmin-rule-exclusions-before.conf
@@ -1103,12 +1103,4 @@ SecRule ARGS:route "@streq /" \
     ctl:ruleRemoveTargetById=951220;RESPONSE_BODY,\
     ctl:ruleRemoveTargetById=953100;RESPONSE_BODY"
 
-SecRule ARGS:route "@streq /preferences/features" \
-    "id:9513920,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ctl:ruleRemoveTargetById=951210;RESPONSE_BODY"
-
 SecMarker "END-PHPMYADMIN-RULE-EXCLUSIONS-PLUGIN-V51-URL-FORMAT"

--- a/plugins/phpmyadmin-rule-exclusions-before.conf
+++ b/plugins/phpmyadmin-rule-exclusions-before.conf
@@ -317,6 +317,7 @@ SecRule REQUEST_FILENAME "@endsWith /import.php" \
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
     ctl:ruleRemoveById=200003,\
+    ctl:ruleRemoveTargetById=932180;FILES:import_file,\
     ctl:ruleRemoveTargetById=933110;FILES:import_file,\
     ctl:ruleRemoveTargetById=951230;TX:sql_error_match,\
     ctl:ruleRemoveTargetById=951230;RESPONSE_BODY,\
@@ -767,6 +768,7 @@ SecRule ARGS:route "@streq /import" \
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
     ctl:ruleRemoveById=200003,\
+    ctl:ruleRemoveTargetById=932180;FILES:import_file,\
     ctl:ruleRemoveTargetById=933110;FILES:import_file,\
     ctl:ruleRemoveTargetById=951230;TX:sql_error_match,\
     ctl:ruleRemoveTargetById=951230;RESPONSE_BODY,\

--- a/plugins/phpmyadmin-rule-exclusions-before.conf
+++ b/plugins/phpmyadmin-rule-exclusions-before.conf
@@ -249,6 +249,8 @@ SecRule REQUEST_FILENAME "@endsWith /lint.php" \
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
     ctl:ruleRemoveTargetById=921110;REQUEST_BODY,\
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
+    ctl:ruleRemoveTargetByTag=attack-xss;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=921110;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=921130;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=930100;ARGS:sql_query,\
@@ -258,11 +260,17 @@ SecRule REQUEST_FILENAME "@endsWith /lint.php" \
     ctl:ruleRemoveTargetById=932105;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932110;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932115;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932120;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932125;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932130;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932140;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932150;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932160;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932230;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932235;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932250;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932260;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932370;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932380;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=933100;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=933120;ARGS:sql_query,\
@@ -273,9 +281,7 @@ SecRule REQUEST_FILENAME "@endsWith /lint.php" \
     ctl:ruleRemoveTargetById=933210;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=934100;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=942100;ARGS:sql_query,\
-    ctl:ruleRemoveTargetById=942360;ARGS:sql_query,\
-    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
-    ctl:ruleRemoveTargetByTag=attack-xss;ARGS:sql_query"
+    ctl:ruleRemoveTargetById=942360;ARGS:sql_query"
 
 # Opening custom SQL editor (tables)
 SecRule REQUEST_FILENAME "@endsWith /tbl_sql.php" \
@@ -346,11 +352,14 @@ SecRule REQUEST_FILENAME "@endsWith /import.php" \
     ctl:ruleRemoveTargetById=932105;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932110;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932115;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932120;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932125;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932130;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932140;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932150;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932160;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932235;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932370;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932380;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=933100;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=933120;ARGS:sql_query,\
@@ -700,6 +709,8 @@ SecRule ARGS:route "@streq /lint" \
     nolog,\
     ver:'phpmyadmin-rule-exclusions-plugin/1.0.0',\
     ctl:ruleRemoveTargetById=921110;REQUEST_BODY,\
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
+    ctl:ruleRemoveTargetByTag=attack-xss;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=921110;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=921130;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=930100;ARGS:sql_query,\
@@ -709,11 +720,17 @@ SecRule ARGS:route "@streq /lint" \
     ctl:ruleRemoveTargetById=932105;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932110;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932115;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932120;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932125;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932130;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932140;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932150;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932160;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932230;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932235;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932250;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932260;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932370;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932380;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=933100;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=933120;ARGS:sql_query,\
@@ -724,9 +741,7 @@ SecRule ARGS:route "@streq /lint" \
     ctl:ruleRemoveTargetById=933210;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=934100;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=942100;ARGS:sql_query,\
-    ctl:ruleRemoveTargetById=942360;ARGS:sql_query,\
-    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
-    ctl:ruleRemoveTargetByTag=attack-xss;ARGS:sql_query"
+    ctl:ruleRemoveTargetById=942360;ARGS:sql_query"
 
 # Opening custom SQL editor (tables)
 SecRule ARGS:route "@streq /table/sql" \
@@ -799,11 +814,14 @@ SecRule ARGS:route "@streq /import" \
     ctl:ruleRemoveTargetById=932105;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932110;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932115;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932120;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932125;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932130;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932150;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932140;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932160;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932235;ARGS:sql_query,\
+    ctl:ruleRemoveTargetById=932370;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=932380;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=933100;ARGS:sql_query,\
     ctl:ruleRemoveTargetById=933120;ARGS:sql_query,\

--- a/tests/regression/phpmyadmin-plugin/9513100.yaml
+++ b/tests/regression/phpmyadmin-plugin/9513100.yaml
@@ -1,0 +1,24 @@
+---
+meta:
+  author: "azurit"
+  description: "Test PhpMyAdmin Plugin"
+  rule_id: 9513100
+tests:
+  - test_id: 1
+    desc: FP inside Referer header
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            Cookie: phpMyAdmin=1
+            Referer: "http://example.com/index.php?sql_query=SELECT+%2A+FROM+%60a%60+where+b+like+%27%25c%25%27"
+          port: 80
+          method: GET
+          version: HTTP/1.1
+          uri: /get
+        output:
+          log:
+            no_expect_ids: [942100]

--- a/tests/regression/phpmyadmin-plugin/9513100.yaml
+++ b/tests/regression/phpmyadmin-plugin/9513100.yaml
@@ -22,3 +22,21 @@ tests:
         output:
           log:
             no_expect_ids: [942100]
+  - test_id: 2
+    desc: FP inside Referer header - new line
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            Cookie: phpMyAdmin=1
+            Referer: "http://example.com/index.php?sql_query=SELECT+%2A+FROM+%60city%60+%0AORDER+BY"
+          port: 80
+          method: GET
+          version: HTTP/1.1
+          uri: /get
+        output:
+          log:
+            no_expect_ids: [921140]

--- a/tests/regression/phpmyadmin-plugin/9513260.yaml
+++ b/tests/regression/phpmyadmin-plugin/9513260.yaml
@@ -1,0 +1,25 @@
+# This test is disabled because it needs changes in the plugin configuration, which is currently not supported by FTW.
+# ---
+# meta:
+#  author: "azurit"
+#  description: "PhpMyAdmin Rule Exclusions Plugin"
+#  rule_id: 9513260
+# tests:
+#  - test_id: 1
+#    desc: FP with typo in SQL query
+#    stages:
+#      - input:
+#          dest_addr: 127.0.0.1
+#          headers:
+#            Host: localhost
+#            User-Agent: "OWASP CRS test agent"
+#            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+#            Cookie: phpMyAdmin=1
+#          port: 80
+#          method: POST
+#          version: HTTP/1.1
+#          uri: /post/lint.php
+#          data: "sql_query=SELECT `k`.`ac FROM"
+#        output:
+#          log:
+#            no_expect_ids: [932125]

--- a/tests/regression/phpmyadmin-plugin/9513290.yaml
+++ b/tests/regression/phpmyadmin-plugin/9513290.yaml
@@ -1,0 +1,25 @@
+# This test is disabled because it needs changes in the plugin configuration, which is currently not supported by FTW.
+# ---
+# meta:
+#  author: "azurit"
+#  description: "PhpMyAdmin Rule Exclusions Plugin"
+#  rule_id: 9513290
+# tests:
+#  - test_id: 1
+#    desc: FP related to data import (command sp)
+#    stages:
+#      - input:
+#          dest_addr: 127.0.0.1
+#          headers:
+#            Host: localhost
+#            User-Agent: "OWASP CRS test agent"
+#            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+#            Cookie: phpMyAdmin=1
+#          port: 80
+#          method: POST
+#          version: HTTP/1.1
+#          uri: /post/import.php
+#          data: sql_query=SELECT%0Asp.id_specific_price%20FROM
+#        output:
+#          log:
+#            no_expect_ids: [932125]

--- a/tests/regression/phpmyadmin-plugin/9513290.yaml
+++ b/tests/regression/phpmyadmin-plugin/9513290.yaml
@@ -23,3 +23,27 @@
 #        output:
 #          log:
 #            no_expect_ids: [932125]
+#  - test_id: 2
+#    desc: FP related to data import from compressed file
+#    stages:
+#      - input:
+#          dest_addr: "127.0.0.1"
+#          headers:
+#            Host: "localhost"
+#            User-Agent: "OWASP CRS test agent"
+#            Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+#            Content-Type: "multipart/form-data; boundary=--------397236876"
+#          port: 80
+#          method: POST
+#          version: HTTP/1.1
+#          uri: /post/import.php
+#          data: |
+#            ----------397236876
+#            Content-Disposition: form-data; name="import_file"; filename="dump.sql.zip"
+#            Content-Type: text/plain
+#
+#            test content
+#            ----------397236876--
+#        output:
+#          log:
+#            no_expect_ids: [932180]

--- a/tests/regression/phpmyadmin-plugin/9513670.yaml
+++ b/tests/regression/phpmyadmin-plugin/9513670.yaml
@@ -1,0 +1,24 @@
+---
+meta:
+  author: "azurit"
+  description: "PhpMyAdmin Rule Exclusions Plugin"
+  rule_id: 9513670
+tests:
+  - test_id: 1
+    desc: FP with typo in SQL query
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            Cookie: phpMyAdmin=1
+          port: 80
+          method: POST
+          version: HTTP/1.1
+          uri: /post/index.php?route=/lint
+          data: "sql_query=SELECT `k`.`ac FROM"
+        output:
+          log:
+            no_expect_ids: [932125]

--- a/tests/regression/phpmyadmin-plugin/9513700.yaml
+++ b/tests/regression/phpmyadmin-plugin/9513700.yaml
@@ -1,0 +1,24 @@
+---
+meta:
+  author: "azurit"
+  description: "PhpMyAdmin Rule Exclusions Plugin"
+  rule_id: 9513700
+tests:
+  - test_id: 1
+    desc: FP related to data import (command sp)
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            Cookie: phpMyAdmin=1
+          port: 80
+          method: GET
+          version: HTTP/1.1
+          uri: /post/index.php?route=/import
+          data: sql_query=SELECT%0Asp.id_specific_price%20FROM
+        output:
+          log:
+            no_expect_ids: [932125]

--- a/tests/regression/phpmyadmin-plugin/9513700.yaml
+++ b/tests/regression/phpmyadmin-plugin/9513700.yaml
@@ -15,10 +15,34 @@ tests:
             Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             Cookie: phpMyAdmin=1
           port: 80
-          method: GET
+          method: POST
           version: HTTP/1.1
           uri: /post/index.php?route=/import
           data: sql_query=SELECT%0Asp.id_specific_price%20FROM
         output:
           log:
             no_expect_ids: [932125]
+  - test_id: 2
+    desc: FP related to data import from compressed file
+    stages:
+      - input:
+          dest_addr: "127.0.0.1"
+          headers:
+            Host: "localhost"
+            User-Agent: "OWASP CRS test agent"
+            Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+            Content-Type: "multipart/form-data; boundary=--------397236876"
+          port: 80
+          method: POST
+          version: HTTP/1.1
+          uri: /post/index.php?route=/import
+          data: |
+            ----------397236876
+            Content-Disposition: form-data; name="import_file"; filename="dump.sql.zip"
+            Content-Type: text/plain
+
+            test content
+            ----------397236876--
+        output:
+          log:
+            no_expect_ids: [932180]


### PR DESCRIPTION
For example typo (missing backtick) in SQL query caused FP:
```
`SELECT `k`.`ac FROM`
```



Fixes: https://github.com/coreruleset/phpmyadmin-rule-exclusions-plugin/issues/37