### PR TITLE
fix: FP when import shows errors

### DIFF
--- a/plugins/phpmyadmin-rule-exclusions-before.conf
+++ b/plugins/phpmyadmin-rule-exclusions-before.conf
@@ -331,6 +331,7 @@ SecRule REQUEST_FILENAME "@endsWith /import.php" \
     ctl:ruleRemoveTargetById=951230;TX:sql_error_match,\
     ctl:ruleRemoveTargetById=951230;RESPONSE_BODY,\
     ctl:ruleRemoveTargetById=953100;RESPONSE_BODY,\
+    ctl:ruleRemoveTargetById=953110;RESPONSE_BODY,\
     ctl:ruleRemoveTargetById=921110;REQUEST_BODY,\
     ctl:ruleRemoveTargetById=942110;ARGS:csv_enclosed,\
     ctl:ruleRemoveTargetById=942330;ARGS:csv_enclosed,\
@@ -812,6 +813,7 @@ SecRule ARGS:route "@streq /import" \
     ctl:ruleRemoveTargetById=951230;TX:sql_error_match,\
     ctl:ruleRemoveTargetById=951230;RESPONSE_BODY,\
     ctl:ruleRemoveTargetById=953100;RESPONSE_BODY,\
+    ctl:ruleRemoveTargetById=953110;RESPONSE_BODY,\
     ctl:ruleRemoveTargetById=921110;REQUEST_BODY,\
     ctl:ruleRemoveTargetById=942360;ARGS:dummy,\
     ctl:ruleRemoveTargetById=942110;ARGS:csv_enclosed,\


### PR DESCRIPTION
When importing data, phpMyAdmin may show various errors which includes parts of imported data i. e. it may display anything.